### PR TITLE
Sort events by event start time, bookings by pickup and event start time

### DIFF
--- a/app/Http/Controllers/Admin/EventAdminController.php
+++ b/app/Http/Controllers/Admin/EventAdminController.php
@@ -17,7 +17,7 @@ class EventAdminController extends Controller
     {
         $events = Event::with(['room:id,name'])
             ->withCount('bookings')
-            ->orderBy('starts_at', 'desc')
+            ->orderBy('starts_at')
             ->get();
 
         $rooms = Room::select('id', 'name')->orderBy('name')->get();

--- a/app/Http/Controllers/Admin/RoomAdminController.php
+++ b/app/Http/Controllers/Admin/RoomAdminController.php
@@ -21,6 +21,7 @@ class RoomAdminController extends Controller
                     ->whereColumn('blocks.room_id', 'rooms.id')
                     ->selectRaw('count(seats.id)'),
             ])
+            ->orderBy('name')
             ->get();
 
         return Inertia::render('Admin/RoomIndex', [

--- a/app/Http/Controllers/BookingController.php
+++ b/app/Http/Controllers/BookingController.php
@@ -16,7 +16,8 @@ class BookingController extends Controller
     public function index()
     {
         $bookings = Booking::where('user_id', auth()->id())
-            ->select('id', 'event_id', 'seat_id', 'name', 'comment', 'picked_up_at', 'created_at', 'booking_code')
+            ->join('events', 'bookings.event_id', '=', 'events.id')
+            ->select('bookings.id', 'bookings.event_id', 'bookings.seat_id', 'bookings.name', 'bookings.comment', 'bookings.picked_up_at', 'bookings.created_at', 'bookings.booking_code')
             ->with([
                 'event:id,name,starts_at,reservation_ends_at,room_id',
                 'event.room:id,name',
@@ -24,7 +25,9 @@ class BookingController extends Controller
                 'seat.row:id,block_id,name',
                 'seat.row.block:id,name',
             ])
-            ->orderBy('created_at', 'desc')
+            ->orderByRaw('bookings.picked_up_at is null desc')
+            ->orderBy('events.reservation_ends_at')
+            ->orderBy('events.starts_at')
             ->paginate(20);
 
         return Inertia::render('Booking/IndexBooking', [

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -17,6 +17,7 @@ class EventController extends Controller
             ->where('reservation_ends_at', '>', now())
             ->where('starts_at', '>', now())
             ->select('id', 'room_id', 'name', 'starts_at', 'reservation_ends_at', 'booking_starts_at', 'tickets', 'max_tickets')
+            ->orderBy('starts_at')
             ->get();
 
         // Manually add tickets_left without triggering the heavy relationship loading


### PR DESCRIPTION
Changes sorting of events and bookings, also makes rooms on admin panel sorted alphabetical, and fixed sorting order on admins event page

# Bookings Index:
<img width="935" height="560" alt="Screenshot 2026-07-14 at 16 30 58" src="https://github.com/user-attachments/assets/aa8f1143-ca6a-4814-9c3d-bd7abbbd098c" />

# Event Index:
<img width="931" height="512" alt="Screenshot 2026-07-14 at 16 32 57" src="https://github.com/user-attachments/assets/5af5efeb-8771-4991-9466-b880613a8cf0" />

Closes #27 
