### PR TITLE
Sort print cards and add master and block layout pages

### DIFF
--- a/app/Http/Controllers/Admin/EventAdminController.php
+++ b/app/Http/Controllers/Admin/EventAdminController.php
@@ -348,7 +348,7 @@ class EventAdminController extends Controller
             $masterBlocks = $room->blocks()
                 ->select('id', 'room_id', 'name', 'position_x', 'position_y')
                 ->with(['rows' => function ($query) {
-                    $query->select('id', 'block_id', 'order')
+                    $query->select('id', 'block_id', 'order', 'alignment')
                         ->orderBy('order')
                         ->with(['seats:id,row_id,number']);
                 }])
@@ -390,6 +390,37 @@ class EventAdminController extends Controller
                 'overview' => $masterCard->render($masterBlocks, $masterStageBlocks, $bookedSeatIds, $mpdf),
             ])->render();
 
+            /*
+            // TEST BUILD: master, order (booked labels), order (all names).
+            $previewBlock = $previewBlocks->first();
+            if ($previewBlock) {
+                // All-seat set so every seat shows its label on the second order card.
+                $allSeatIds = [];
+                foreach ($previewBlock->rows as $row) {
+                    foreach ($row->seats as $seat) {
+                        $allSeatIds[$seat->id] = true;
+                    }
+                }
+
+                $pages[] = view('pdf.order-card', [
+                    'info' => (object) [
+                        'event_name' => $event->name,
+                        'block_name' => 'Block '.$previewBlock->name,
+                    ],
+                    'preview' => $orderCard->render($previewBlock, $bookedSeatIds, $mpdf),
+                ])->render();
+
+                $pages[] = view('pdf.order-card', [
+                    'info' => (object) [
+                        'event_name' => $event->name,
+                        'block_name' => 'Block '.$previewBlock->name,
+                    ],
+                    // Fill only booked seats black, but label every seat.
+                    'preview' => $orderCard->render($previewBlock, $bookedSeatIds, $mpdf, $allSeatIds),
+                ])->render();
+            }
+            */
+
             $currentBlockId = null;
 
             foreach ($bookings as $booking) {
@@ -406,7 +437,7 @@ class EventAdminController extends Controller
                             'block_name' => 'Block '.$block->name,
                         ],
                         'preview' => $previewBlock
-                            ? $orderCard->render($previewBlock, $bookedSeatIds)
+                            ? $orderCard->render($previewBlock, $bookedSeatIds, $mpdf)
                             : null,
                     ])->render();
                 }

--- a/app/Http/Controllers/Admin/EventAdminController.php
+++ b/app/Http/Controllers/Admin/EventAdminController.php
@@ -8,12 +8,13 @@ use App\Models\Booking;
 use App\Models\Event;
 use App\Models\Room;
 use App\Models\User;
-use Carbon\Carbon;
 use App\Services\Svg\MasterCardSvgGenerator;
 use App\Services\Svg\OrderCardSvgGenerator;
 use App\Services\Svg\SvgUtilities;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 
@@ -309,6 +310,7 @@ class EventAdminController extends Controller
                 $bookingsQuery->whereNotNull('picked_up_at');
             }
 
+            // Wind seats by row order so placing the cards is easier and faster for the runners.
             $bookings = $bookingsQuery->get()->sortBy(function ($booking) {
                 $block = $booking->seat->row->block;
                 $rowOrder = $booking->seat->row->order;
@@ -341,8 +343,7 @@ class EventAdminController extends Controller
                 ->get()
                 ->keyBy('id');
 
-            $bookedSeatIds = $bookings->pluck('seat.id')->all();
-            $bookedSeatIds = array_fill_keys($bookedSeatIds, true);
+            $bookedSeatIds = array_fill_keys($bookings->pluck('seat.id')->all(), true);
 
             $room = $event->room;
             $masterBlocks = $room->blocks()
@@ -390,37 +391,6 @@ class EventAdminController extends Controller
                 'overview' => $masterCard->render($masterBlocks, $masterStageBlocks, $bookedSeatIds, $mpdf),
             ])->render();
 
-            /*
-            // TEST BUILD: master, order (booked labels), order (all names).
-            $previewBlock = $previewBlocks->first();
-            if ($previewBlock) {
-                // All-seat set so every seat shows its label on the second order card.
-                $allSeatIds = [];
-                foreach ($previewBlock->rows as $row) {
-                    foreach ($row->seats as $seat) {
-                        $allSeatIds[$seat->id] = true;
-                    }
-                }
-
-                $pages[] = view('pdf.order-card', [
-                    'info' => (object) [
-                        'event_name' => $event->name,
-                        'block_name' => 'Block '.$previewBlock->name,
-                    ],
-                    'preview' => $orderCard->render($previewBlock, $bookedSeatIds, $mpdf),
-                ])->render();
-
-                $pages[] = view('pdf.order-card', [
-                    'info' => (object) [
-                        'event_name' => $event->name,
-                        'block_name' => 'Block '.$previewBlock->name,
-                    ],
-                    // Fill only booked seats black, but label every seat.
-                    'preview' => $orderCard->render($previewBlock, $bookedSeatIds, $mpdf, $allSeatIds),
-                ])->render();
-            }
-            */
-
             $currentBlockId = null;
 
             foreach ($bookings as $booking) {
@@ -458,7 +428,7 @@ class EventAdminController extends Controller
             }
 
             // Return PDF for browser preview
-            $filename = 'seating-cards-'.\Str::slug($event->name).'-'.date('Y-m-d').'.pdf';
+            $filename = 'seating-cards-'.Str::slug($event->name).'-'.date('Y-m-d').'.pdf';
 
             return response($mpdf->Output($filename, 'S'))
                 ->header('Content-Type', 'application/pdf')

--- a/app/Http/Controllers/Admin/EventAdminController.php
+++ b/app/Http/Controllers/Admin/EventAdminController.php
@@ -347,7 +347,7 @@ class EventAdminController extends Controller
 
             $room = $event->room;
             $masterBlocks = $room->blocks()
-                ->select('id', 'room_id', 'name', 'position_x', 'position_y')
+                ->select('id', 'room_id', 'name', 'position_x', 'position_y', 'rotation')
                 ->with(['rows' => function ($query) {
                     $query->select('id', 'block_id', 'order', 'alignment')
                         ->orderBy('order')

--- a/app/Http/Controllers/Admin/EventAdminController.php
+++ b/app/Http/Controllers/Admin/EventAdminController.php
@@ -299,6 +299,7 @@ class EventAdminController extends Controller
             $event = Event::with('room')->findOrFail($id);
 
             $bookingsQuery = Booking::where('event_id', $id)
+                ->select('id', 'event_id', 'user_id', 'seat_id', 'name', 'picked_up_at')
                 ->with([
                     'user:id,name',
                     'seat:id,row_id,label,number',

--- a/app/Http/Controllers/Admin/EventAdminController.php
+++ b/app/Http/Controllers/Admin/EventAdminController.php
@@ -294,17 +294,31 @@ class EventAdminController extends Controller
             $event = Event::with('room')->findOrFail($id);
 
             $bookingsQuery = Booking::where('event_id', $id)
-                ->with(['user:id,name', 'seat:id,row_id,label,number', 'seat.row:id,block_id,name', 'seat.row.block:id,name']);
+                ->with([
+                    'user:id,name',
+                    'seat:id,row_id,label,number',
+                    'seat.row:id,block_id,name,order',
+                    'seat.row.block:id,name,position_x,position_y',
+                ]);
 
             if (! request()->boolean('include_unpicked')) {
                 $bookingsQuery->whereNotNull('picked_up_at');
             }
 
-            $bookings = $bookingsQuery->get()->sortBy([
-                ['seat.row.block.name', 'asc'],
-                ['seat.row.name', 'asc'],
-                ['seat.number', 'asc'],
-            ]);
+            $bookings = $bookingsQuery->get()->sortBy(function ($booking) {
+                $block = $booking->seat->row->block;
+                $rowOrder = $booking->seat->row->order;
+                $seatNumber = $booking->seat->number;
+
+                $seatSort = $rowOrder % 2 === 1 ? $seatNumber : -$seatNumber;
+
+                return [
+                    $block->position_y,
+                    $block->position_x,
+                    $rowOrder,
+                    $seatSort,
+                ];
+            });
 
             if ($bookings->isEmpty()) {
                 return back()->with('error', 'No bookings found for this event to generate seating cards.');

--- a/app/Http/Controllers/Admin/EventAdminController.php
+++ b/app/Http/Controllers/Admin/EventAdminController.php
@@ -3,11 +3,15 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\Block;
 use App\Models\Booking;
 use App\Models\Event;
 use App\Models\Room;
 use App\Models\User;
 use Carbon\Carbon;
+use App\Services\Svg\MasterCardSvgGenerator;
+use App\Services\Svg\OrderCardSvgGenerator;
+use App\Services\Svg\SvgUtilities;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
@@ -324,6 +328,35 @@ class EventAdminController extends Controller
                 return back()->with('error', 'No bookings found for this event to generate seating cards.');
             }
 
+            $blockIds = $bookings->pluck('seat.row.block.id')->unique()->all();
+
+            $previewBlocks = Block::whereIn('id', $blockIds)
+                ->with(['rows' => function ($query) {
+                    $query->select('id', 'block_id', 'name', 'order', 'alignment')
+                        ->orderBy('order')
+                        ->with(['seats' => function ($q) {
+                            $q->select('id', 'row_id', 'label', 'number')->orderBy('number');
+                        }]);
+                }])
+                ->get()
+                ->keyBy('id');
+
+            $bookedSeatIds = $bookings->pluck('seat.id')->all();
+            $bookedSeatIds = array_fill_keys($bookedSeatIds, true);
+
+            $room = $event->room;
+            $masterBlocks = $room->blocks()
+                ->select('id', 'room_id', 'name', 'position_x', 'position_y')
+                ->with(['rows' => function ($query) {
+                    $query->select('id', 'block_id', 'order')
+                        ->orderBy('order')
+                        ->with(['seats:id,row_id,number']);
+                }])
+                ->get();
+            $masterStageBlocks = $room->stageBlocks()
+                ->select('id', 'room_id', 'name', 'position_x', 'position_y')
+                ->get();
+
             // mPDF configuration with custom Zhurzh font
             $mpdf = new \Mpdf\Mpdf([
                 'format' => 'A4-L',
@@ -345,27 +378,52 @@ class EventAdminController extends Controller
             // Set execution time limit for large batches
             set_time_limit(300); // 5 minutes
 
-            // Process all bookings and generate pages
-            foreach ($bookings as $index => $booking) {
-                try {
-                    // Use the blade template without background image
-                    $html = view('pdf.seating-card-single', [
-                        'booking' => $booking,
-                        'event' => $event,
+            $svg = new SvgUtilities;
+            $masterCard = new MasterCardSvgGenerator($svg);
+            $orderCard = new OrderCardSvgGenerator($svg);
+
+            $pages = [];
+
+            $pages[] = view('pdf.master-page', [
+                'event_name' => $event->name,
+                'room_name' => $room->name,
+                'overview' => $masterCard->render($masterBlocks, $masterStageBlocks, $bookedSeatIds, $mpdf),
+            ])->render();
+
+            $currentBlockId = null;
+
+            foreach ($bookings as $booking) {
+                $block = $booking->seat->row->block;
+
+                if ($block->id !== $currentBlockId) {
+                    $currentBlockId = $block->id;
+
+                    $previewBlock = $previewBlocks->get($block->id);
+
+                    $pages[] = view('pdf.order-card', [
+                        'info' => (object) [
+                            'event_name' => $event->name,
+                            'block_name' => 'Block '.$block->name,
+                        ],
+                        'preview' => $previewBlock
+                            ? $orderCard->render($previewBlock, $bookedSeatIds)
+                            : null,
                     ])->render();
-
-                    $mpdf->WriteHTML($html);
-
-                    // Add page break after each booking except the last one
-                    if ($index < $bookings->count() - 1) {
-                        $mpdf->AddPage();
-                    }
-
-                } catch (\Exception $e) {
-                    \Log::error("Error processing booking {$booking->id}: ".$e->getMessage());
-
-                    continue; // Skip this booking and continue
                 }
+
+                $pages[] = view('pdf.seating-card-single', [
+                    'booking' => $booking,
+                    'event' => $event,
+                ])->render();
+            }
+
+            // Write each pre-rendered page to the PDF.
+            foreach ($pages as $index => $html) {
+                if ($index > 0) {
+                    $mpdf->AddPage();
+                }
+
+                $mpdf->WriteHTML($html);
             }
 
             // Return PDF for browser preview

--- a/app/Services/Svg/MasterCardSvgGenerator.php
+++ b/app/Services/Svg/MasterCardSvgGenerator.php
@@ -7,6 +7,18 @@ use Mpdf\Mpdf;
 
 class MasterCardSvgGenerator
 {
+    private const PITCH = 15;       // seat spacing
+
+    private const HEADER = 30;      // space above a block's seat grid for its name
+
+    private const IN_PAD = 10;      // block border to seat grid
+
+    private const CELL_GAP = 18;    // gap between grid cells
+
+    private const PAD = 18;         // outer padding
+
+    private const STAGE_SIZE = 90;
+
     public function __construct(private SvgUtilities $svg) {}
 
     /**
@@ -14,22 +26,47 @@ class MasterCardSvgGenerator
      *
      * @param  Collection  $blocks  Seating blocks with rows.seats.
      * @param  Collection  $stageBlocks  Stage blocks.
-     * @param  array<int,bool>  $bookedSeatIds  Set of booked seat IDs (id => true).
+     * @param  array<int,bool>  $bookedSeatIds  Set of booked seat IDs.
      */
-    public function render($blocks, $stageBlocks, array $bookedSeatIds, Mpdf $mpdf): string
+    public function render(Collection $blocks, Collection $stageBlocks, array $bookedSeatIds, Mpdf $mpdf): string
     {
-        $pitch = 15;
-        $header = 30;    // space for the block name above its seat grid
-        $inPad = 10;     // block border -> seat grid padding
-        $cgap = 18;      // gap between grid cells
-        $pad = 18;       // outer padding
-        $stageSize = 90;
+        $cells = $this->cells($blocks, $stageBlocks);
+        if (empty($cells)) {
+            return '';
+        }
 
+        [$colW, $rowH] = $this->gridSizes($cells);
+        [$colX, $width] = $this->gridLinePositions($colW);
+        [$rowY, $height] = $this->gridLinePositions($rowH);
+
+        $svg = '';
+        foreach ($cells as $c) {
+            $cw = $c['type'] === 'stage' ? $colW[$c['x']] : $c['w'];
+            $bx = $colX[$c['x']] + ($colW[$c['x']] - $cw) / 2;
+            $by = $rowY[$c['y']];
+            $svg .= $c['type'] === 'stage'
+                ? $this->stageCell($c, $bx, $by, $cw, $mpdf)
+                : $this->seatingCell($c, $bx, $by, $bookedSeatIds, $mpdf);
+        }
+
+        $scale = min(200 / $width, 110 / $height);
+
+        return $this->svg->document($width, $height, $width * $scale, $height * $scale, $svg);
+    }
+
+    /**
+     * Placed blocks as grid cells.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    private function cells(Collection $blocks, Collection $stageBlocks): array
+    {
         $placed = fn ($b) => $b->position_x !== null && $b->position_y !== null && $b->position_x >= 0 && $b->position_y >= 0;
+
         $cells = [];
         foreach ($stageBlocks as $sb) {
             if ($placed($sb)) {
-                $cells[] = ['x' => $sb->position_x, 'y' => $sb->position_y, 'type' => 'stage', 'block' => $sb, 'w' => $stageSize, 'h' => $stageSize];
+                $cells[] = ['x' => $sb->position_x, 'y' => $sb->position_y, 'type' => 'stage', 'block' => $sb, 'w' => self::STAGE_SIZE, 'h' => self::STAGE_SIZE];
             }
         }
         foreach ($blocks as $b) {
@@ -41,78 +78,86 @@ class MasterCardSvgGenerator
             $cells[] = [
                 'x' => $b->position_x, 'y' => $b->position_y, 'type' => 'seating', 'block' => $b, 'rows' => $rows,
                 'maxSeats' => $maxSeats,
-                'w' => $inPad * 2 + $maxSeats * $pitch,
-                'h' => $header + $inPad + max($rows->count(), 1) * $pitch,
+                'w' => self::IN_PAD * 2 + $maxSeats * self::PITCH,
+                'h' => self::HEADER + self::IN_PAD + max($rows->count(), 1) * self::PITCH,
             ];
         }
-        if (empty($cells)) {
-            return '';
-        }
 
+        return $cells;
+    }
+
+    /**
+     * @param  array<int,array<string,mixed>>  $cells
+     * @return array{0: array<int,float>, 1: array<int,float>}
+     */
+    private function gridSizes(array $cells): array
+    {
         $colW = $rowH = [];
         foreach ($cells as $c) {
             $colW[$c['x']] = max($colW[$c['x']] ?? 0, $c['w']);
             $rowH[$c['y']] = max($rowH[$c['y']] ?? 0, $c['h']);
         }
-        $offsets = function (array $sizes) use ($cgap, $pad, $pitch) {
-            $pos = [];
-            $acc = $pad;
-            for ($i = min(array_keys($sizes)); $i <= max(array_keys($sizes)); $i++) {
-                $pos[$i] = $acc;
-                $acc += ($sizes[$i] ?? $pitch) + $cgap;
-            }
 
-            return [$pos, $acc - $cgap + $pad];
-        };
-        [$colX, $width] = $offsets($colW);
-        [$rowY, $height] = $offsets($rowH);
+        return [$colW, $rowH];
+    }
+
+    /**
+     * @param  array<int,float>  $sizes  Cell size per grid index
+     * @return array{0: array<int,float>, 1: float} [start pixel per index, total length]
+     */
+    private function gridLinePositions(array $sizes): array
+    {
+        $starts = [];
+        $cursor = self::PAD;
+        for ($i = min(array_keys($sizes)); $i <= max(array_keys($sizes)); $i++) {
+            $starts[$i] = $cursor;
+            $cursor += ($sizes[$i] ?? self::PITCH) + self::CELL_GAP;
+        }
+
+        return [$starts, $cursor - self::CELL_GAP + self::PAD];
+    }
+
+    private function stageCell(array $c, float $bx, float $by, float $cw, Mpdf $mpdf): string
+    {
+        $sz = SvgUtilities::SIZE_STAGE_LABEL;
+
+        return $this->svg->rect($bx, $by, $cw, $c['h'], '#000000', 2, 10)
+            .$this->svg->centeredLabelX($mpdf, $c['block']->name ?: 'Stage', $sz, '#ffffff', $bx + $cw / 2, $by + $c['h'] / 2 + $sz * SvgUtilities::BASELINE_FACTOR, $cw - 12);
+    }
+
+    private function seatingCell(array $c, float $bx, float $by, array $bookedSeatIds, Mpdf $mpdf): string
+    {
+        $cxMid = $bx + $c['w'] / 2;
+
+        return $this->svg->rect($bx, $by, $c['w'], $c['h'], 'none', 3, 10)
+            .$this->svg->centeredLabelX($mpdf, $c['block']->name, SvgUtilities::SIZE_BLOCK_LABEL, '#000000', $cxMid, $by + 22, $c['w'] - 12)
+            .$this->seatDots($c, $cxMid, $by, $bookedSeatIds);
+    }
+
+    private function seatDots(array $c, float $cxMid, float $by, array $bookedSeatIds): string
+    {
+        $dot = self::PITCH * 0.7;
+        $gridWidth = $c['maxSeats'] * self::PITCH;
+        $gridLeft = $cxMid - $gridWidth / 2;
+        $gridTop = $by + self::HEADER + self::PITCH / 2;
 
         $svg = '';
-        foreach ($cells as $c) {
-            $cw = $c['type'] === 'stage' ? $colW[$c['x']] : $c['w'];
-            $bx = $colX[$c['x']] + ($colW[$c['x']] - $cw) / 2;
-            $by = $rowY[$c['y']];
-            $cxMid = $bx + $cw / 2;
-
-            if ($c['type'] === 'stage') {
-                $svg .= sprintf('<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f" rx="10" ry="10" fill="#000000" stroke="#000000" stroke-width="2"/>', $bx, $by, $cw, $c['h']);
-                $sz = SvgUtilities::SIZE_STAGE_LABEL;
-                $svg .= $this->svg->centeredLabel($mpdf, $c['block']->name ?: 'Stage', $sz, '#ffffff', $cxMid, $by + $c['h'] / 2 + $sz * SvgUtilities::BASELINE_FACTOR, $cw - 12);
-
-                continue;
-            }
-
-            $svg .= sprintf('<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f" rx="10" ry="10" fill="none" stroke="#000000" stroke-width="3"/>', $bx, $by, $c['w'], $c['h']);
-            $svg .= $this->svg->centeredLabel($mpdf, $c['block']->name, SvgUtilities::SIZE_BLOCK_LABEL, '#000000', $cxMid, $by + 22, $c['w'] - 12);
-
-            $dot = $pitch * 0.7;
-            $gridWidth = $c['maxSeats'] * $pitch;
-            $gridLeft = $cxMid - $gridWidth / 2;
-            $gridTop = $by + $header + $pitch / 2;
-            foreach ($c['rows'] as $ri => $row) {
-                $seats = $row->seats->sortBy('number')->values();
-                $rowWidth = $seats->count() * $pitch;
-                $alignment = $row->alignment ?? 'center';
-                $rowLeft = match ($alignment) {
-                    'left' => $gridLeft + $pitch / 2,
-                    'right' => $gridLeft + $gridWidth - $rowWidth + $pitch / 2,
-                    default => $cxMid - $rowWidth / 2 + $pitch / 2,
-                };
-                foreach ($seats as $ci => $seat) {
-                    $svg .= sprintf(
-                        '<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f" rx="2" ry="2" fill="%s" stroke="#000000" stroke-width="1"/>',
-                        $rowLeft + $ci * $pitch - $dot / 2, $gridTop + $ri * $pitch - $dot / 2, $dot, $dot,
-                        isset($bookedSeatIds[$seat->id]) ? '#000000' : '#ffffff'
-                    );
-                }
+        foreach ($c['rows'] as $ri => $row) {
+            $seats = $row->seats->sortBy('number')->values();
+            $rowWidth = $seats->count() * self::PITCH;
+            $rowLeft = match ($row->alignment ?? 'center') {
+                'left' => $gridLeft + self::PITCH / 2,
+                'right' => $gridLeft + $gridWidth - $rowWidth + self::PITCH / 2,
+                default => $cxMid - $rowWidth / 2 + self::PITCH / 2,
+            };
+            foreach ($seats as $ci => $seat) {
+                $svg .= $this->svg->rect(
+                    $rowLeft + $ci * self::PITCH - $dot / 2, $gridTop + $ri * self::PITCH - $dot / 2, $dot, $dot,
+                    isset($bookedSeatIds[$seat->id]) ? '#000000' : '#ffffff', 1, 2
+                );
             }
         }
 
-        $scale = min(200 / $width, 110 / $height);
-
-        return sprintf(
-            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d" width="%smm" height="%smm">%s</svg>',
-            $width, $height, round($width * $scale, 1), round($height * $scale, 1), $svg
-        );
+        return $svg;
     }
 }

--- a/app/Services/Svg/MasterCardSvgGenerator.php
+++ b/app/Services/Svg/MasterCardSvgGenerator.php
@@ -167,8 +167,8 @@ class MasterCardSvgGenerator
                 $seatPos = $seatStart + $ci;
                 [$gc, $gr] = match ($c['rotation']) {
                     90 => [$rowCount - 1 - $ri, $seatPos],
-                    270 => [$ri, $seatPos],
-                    180 => [$seatPos, $rowCount - 1 - $ri],
+                    270 => [$ri, $c['gridRows'] - 1 - $seatPos],
+                    180 => [$gridCols - 1 - $seatPos, $rowCount - 1 - $ri],
                     default => [$seatPos, $ri],
                 };
                 $svg .= $this->svg->rect(

--- a/app/Services/Svg/MasterCardSvgGenerator.php
+++ b/app/Services/Svg/MasterCardSvgGenerator.php
@@ -40,6 +40,7 @@ class MasterCardSvgGenerator
             $maxSeats = max((int) $rows->max(fn ($r) => $r->seats->count()), 1);
             $cells[] = [
                 'x' => $b->position_x, 'y' => $b->position_y, 'type' => 'seating', 'block' => $b, 'rows' => $rows,
+                'maxSeats' => $maxSeats,
                 'w' => $inPad * 2 + $maxSeats * $pitch,
                 'h' => $header + $inPad + max($rows->count(), 1) * $pitch,
             ];
@@ -68,25 +69,35 @@ class MasterCardSvgGenerator
 
         $svg = '';
         foreach ($cells as $c) {
-            $bx = $colX[$c['x']] + ($colW[$c['x']] - $c['w']) / 2;
-            $by = $rowY[$c['y']] + ($rowH[$c['y']] - $c['h']) / 2;
-            $cxMid = $bx + $c['w'] / 2;
+            $cw = $c['type'] === 'stage' ? $colW[$c['x']] : $c['w'];
+            $bx = $colX[$c['x']] + ($colW[$c['x']] - $cw) / 2;
+            $by = $rowY[$c['y']];
+            $cxMid = $bx + $cw / 2;
 
             if ($c['type'] === 'stage') {
-                $svg .= sprintf('<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f" rx="10" ry="10" fill="#000000" stroke="#000000" stroke-width="2"/>', $bx, $by, $c['w'], $c['h']);
-                $svg .= $this->svg->centeredLabel($mpdf, $c['block']->name ?: 'Stage', 24, '#ffffff', $cxMid, $by + $c['h'] / 2 + 24 * 0.35, $c['w'] - 12);
+                $svg .= sprintf('<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f" rx="10" ry="10" fill="#000000" stroke="#000000" stroke-width="2"/>', $bx, $by, $cw, $c['h']);
+                $sz = SvgUtilities::SIZE_STAGE_LABEL;
+                $svg .= $this->svg->centeredLabel($mpdf, $c['block']->name ?: 'Stage', $sz, '#ffffff', $cxMid, $by + $c['h'] / 2 + $sz * SvgUtilities::BASELINE_FACTOR, $cw - 12);
 
                 continue;
             }
 
             $svg .= sprintf('<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f" rx="10" ry="10" fill="none" stroke="#000000" stroke-width="3"/>', $bx, $by, $c['w'], $c['h']);
-            $svg .= $this->svg->centeredLabel($mpdf, $c['block']->name, 20, '#000000', $cxMid, $by + 22, $c['w'] - 12);
+            $svg .= $this->svg->centeredLabel($mpdf, $c['block']->name, SvgUtilities::SIZE_BLOCK_LABEL, '#000000', $cxMid, $by + 22, $c['w'] - 12);
 
             $dot = $pitch * 0.7;
+            $gridWidth = $c['maxSeats'] * $pitch;
+            $gridLeft = $cxMid - $gridWidth / 2;
             $gridTop = $by + $header + $pitch / 2;
             foreach ($c['rows'] as $ri => $row) {
                 $seats = $row->seats->sortBy('number')->values();
-                $rowLeft = $cxMid - ($seats->count() * $pitch) / 2 + $pitch / 2;
+                $rowWidth = $seats->count() * $pitch;
+                $alignment = $row->alignment ?? 'center';
+                $rowLeft = match ($alignment) {
+                    'left' => $gridLeft + $pitch / 2,
+                    'right' => $gridLeft + $gridWidth - $rowWidth + $pitch / 2,
+                    default => $cxMid - $rowWidth / 2 + $pitch / 2,
+                };
                 foreach ($seats as $ci => $seat) {
                     $svg .= sprintf(
                         '<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f" rx="2" ry="2" fill="%s" stroke="#000000" stroke-width="1"/>',
@@ -97,7 +108,7 @@ class MasterCardSvgGenerator
             }
         }
 
-        $scale = min(200 / $width, 90 / $height);
+        $scale = min(200 / $width, 110 / $height);
 
         return sprintf(
             '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d" width="%smm" height="%smm">%s</svg>',

--- a/app/Services/Svg/MasterCardSvgGenerator.php
+++ b/app/Services/Svg/MasterCardSvgGenerator.php
@@ -45,7 +45,7 @@ class MasterCardSvgGenerator
             $bx = $colX[$c['x']] + ($colW[$c['x']] - $cw) / 2;
             $by = $rowY[$c['y']];
             $svg .= $c['type'] === 'stage'
-                ? $this->stageCell($c, $bx, $by, $cw, $mpdf)
+                ? $this->stageCell($c, $bx, $by, $cw, $rowH[$c['y']], $mpdf)
                 : $this->seatingCell($c, $bx, $by, $bookedSeatIds, $mpdf);
         }
 
@@ -75,11 +75,18 @@ class MasterCardSvgGenerator
             }
             $rows = $b->rows->sortBy('order')->values();
             $maxSeats = max((int) $rows->max(fn ($r) => $r->seats->count()), 1);
+            $rotation = (int) ($b->rotation ?? 0);
+
+            $vertical = $rotation === 90 || $rotation === 270;
+            $gridCols = $vertical ? max($rows->count(), 1) : $maxSeats;
+            $gridRows = $vertical ? $maxSeats : max($rows->count(), 1);
+
             $cells[] = [
                 'x' => $b->position_x, 'y' => $b->position_y, 'type' => 'seating', 'block' => $b, 'rows' => $rows,
-                'maxSeats' => $maxSeats,
-                'w' => self::IN_PAD * 2 + $maxSeats * self::PITCH,
-                'h' => self::HEADER + self::IN_PAD + max($rows->count(), 1) * self::PITCH,
+                'maxSeats' => $maxSeats, 'rotation' => $rotation,
+                'gridCols' => $gridCols, 'gridRows' => $gridRows,
+                'w' => self::IN_PAD * 2 + $gridCols * self::PITCH,
+                'h' => self::HEADER + self::IN_PAD + $gridRows * self::PITCH,
             ];
         }
 
@@ -117,12 +124,12 @@ class MasterCardSvgGenerator
         return [$starts, $cursor - self::CELL_GAP + self::PAD];
     }
 
-    private function stageCell(array $c, float $bx, float $by, float $cw, Mpdf $mpdf): string
+    private function stageCell(array $c, float $bx, float $by, float $cw, float $ch, Mpdf $mpdf): string
     {
         $sz = SvgUtilities::SIZE_STAGE_LABEL;
 
-        return $this->svg->rect($bx, $by, $cw, $c['h'], '#000000', 2, 10)
-            .$this->svg->centeredLabelX($mpdf, $c['block']->name ?: 'Stage', $sz, '#ffffff', $bx + $cw / 2, $by + $c['h'] / 2 + $sz * SvgUtilities::BASELINE_FACTOR, $cw - 12);
+        return $this->svg->rect($bx, $by, $cw, $ch, '#000000', 2, 10)
+            .$this->svg->centeredLabelX($mpdf, $c['block']->name ?: 'Stage', $sz, '#ffffff', $bx + $cw / 2, $by + $ch / 2 + $sz * SvgUtilities::BASELINE_FACTOR, $cw - 12);
     }
 
     private function seatingCell(array $c, float $bx, float $by, array $bookedSeatIds, Mpdf $mpdf): string
@@ -137,22 +144,36 @@ class MasterCardSvgGenerator
     private function seatDots(array $c, float $cxMid, float $by, array $bookedSeatIds): string
     {
         $dot = self::PITCH * 0.7;
-        $gridWidth = $c['maxSeats'] * self::PITCH;
+        $gridCols = $c['gridCols'];
+        $rowCount = max($c['rows']->count(), 1);
+        $gridWidth = $gridCols * self::PITCH;
         $gridLeft = $cxMid - $gridWidth / 2;
         $gridTop = $by + self::HEADER + self::PITCH / 2;
+        $vertical = $c['rotation'] === 90 || $c['rotation'] === 270;
 
         $svg = '';
         foreach ($c['rows'] as $ri => $row) {
             $seats = $row->seats->sortBy('number')->values();
-            $rowWidth = $seats->count() * self::PITCH;
-            $rowLeft = match ($row->alignment ?? 'center') {
-                'left' => $gridLeft + self::PITCH / 2,
-                'right' => $gridLeft + $gridWidth - $rowWidth + self::PITCH / 2,
-                default => $cxMid - $rowWidth / 2 + self::PITCH / 2,
+            $count = $seats->count();
+
+            $seatSlack = ($vertical ? $c['gridRows'] : $gridCols) - $count;
+            $seatStart = match ($row->alignment ?? 'center') {
+                'left' => 0,
+                'right' => $seatSlack,
+                default => $seatSlack / 2,
             };
+
             foreach ($seats as $ci => $seat) {
+                $seatPos = $seatStart + $ci;
+                [$gc, $gr] = match ($c['rotation']) {
+                    90 => [$rowCount - 1 - $ri, $seatPos],
+                    270 => [$ri, $seatPos],
+                    180 => [$seatPos, $rowCount - 1 - $ri],
+                    default => [$seatPos, $ri],
+                };
                 $svg .= $this->svg->rect(
-                    $rowLeft + $ci * self::PITCH - $dot / 2, $gridTop + $ri * self::PITCH - $dot / 2, $dot, $dot,
+                    $gridLeft + $gc * self::PITCH + self::PITCH / 2 - $dot / 2,
+                    $gridTop + $gr * self::PITCH - $dot / 2, $dot, $dot,
                     isset($bookedSeatIds[$seat->id]) ? '#000000' : '#ffffff', 1, 2
                 );
             }

--- a/app/Services/Svg/MasterCardSvgGenerator.php
+++ b/app/Services/Svg/MasterCardSvgGenerator.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Services\Svg;
+
+use Illuminate\Support\Collection;
+use Mpdf\Mpdf;
+
+class MasterCardSvgGenerator
+{
+    public function __construct(private SvgUtilities $svg) {}
+
+    /**
+     * Master room overview.
+     *
+     * @param  Collection  $blocks  Seating blocks with rows.seats.
+     * @param  Collection  $stageBlocks  Stage blocks.
+     * @param  array<int,bool>  $bookedSeatIds  Set of booked seat IDs (id => true).
+     */
+    public function render($blocks, $stageBlocks, array $bookedSeatIds, Mpdf $mpdf): string
+    {
+        $pitch = 15;
+        $header = 30;    // space for the block name above its seat grid
+        $inPad = 10;     // block border -> seat grid padding
+        $cgap = 18;      // gap between grid cells
+        $pad = 18;       // outer padding
+        $stageSize = 90;
+
+        $placed = fn ($b) => $b->position_x !== null && $b->position_y !== null && $b->position_x >= 0 && $b->position_y >= 0;
+        $cells = [];
+        foreach ($stageBlocks as $sb) {
+            if ($placed($sb)) {
+                $cells[] = ['x' => $sb->position_x, 'y' => $sb->position_y, 'type' => 'stage', 'block' => $sb, 'w' => $stageSize, 'h' => $stageSize];
+            }
+        }
+        foreach ($blocks as $b) {
+            if (! $placed($b)) {
+                continue;
+            }
+            $rows = $b->rows->sortBy('order')->values();
+            $maxSeats = max((int) $rows->max(fn ($r) => $r->seats->count()), 1);
+            $cells[] = [
+                'x' => $b->position_x, 'y' => $b->position_y, 'type' => 'seating', 'block' => $b, 'rows' => $rows,
+                'w' => $inPad * 2 + $maxSeats * $pitch,
+                'h' => $header + $inPad + max($rows->count(), 1) * $pitch,
+            ];
+        }
+        if (empty($cells)) {
+            return '';
+        }
+
+        $colW = $rowH = [];
+        foreach ($cells as $c) {
+            $colW[$c['x']] = max($colW[$c['x']] ?? 0, $c['w']);
+            $rowH[$c['y']] = max($rowH[$c['y']] ?? 0, $c['h']);
+        }
+        $offsets = function (array $sizes) use ($cgap, $pad, $pitch) {
+            $pos = [];
+            $acc = $pad;
+            for ($i = min(array_keys($sizes)); $i <= max(array_keys($sizes)); $i++) {
+                $pos[$i] = $acc;
+                $acc += ($sizes[$i] ?? $pitch) + $cgap;
+            }
+
+            return [$pos, $acc - $cgap + $pad];
+        };
+        [$colX, $width] = $offsets($colW);
+        [$rowY, $height] = $offsets($rowH);
+
+        $svg = '';
+        foreach ($cells as $c) {
+            $bx = $colX[$c['x']] + ($colW[$c['x']] - $c['w']) / 2;
+            $by = $rowY[$c['y']] + ($rowH[$c['y']] - $c['h']) / 2;
+            $cxMid = $bx + $c['w'] / 2;
+
+            if ($c['type'] === 'stage') {
+                $svg .= sprintf('<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f" rx="10" ry="10" fill="#000000" stroke="#000000" stroke-width="2"/>', $bx, $by, $c['w'], $c['h']);
+                $svg .= $this->svg->centeredLabel($mpdf, $c['block']->name ?: 'Stage', 24, '#ffffff', $cxMid, $by + $c['h'] / 2 + 24 * 0.35, $c['w'] - 12);
+
+                continue;
+            }
+
+            $svg .= sprintf('<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f" rx="10" ry="10" fill="none" stroke="#000000" stroke-width="3"/>', $bx, $by, $c['w'], $c['h']);
+            $svg .= $this->svg->centeredLabel($mpdf, $c['block']->name, 20, '#000000', $cxMid, $by + 22, $c['w'] - 12);
+
+            $dot = $pitch * 0.7;
+            $gridTop = $by + $header + $pitch / 2;
+            foreach ($c['rows'] as $ri => $row) {
+                $seats = $row->seats->sortBy('number')->values();
+                $rowLeft = $cxMid - ($seats->count() * $pitch) / 2 + $pitch / 2;
+                foreach ($seats as $ci => $seat) {
+                    $svg .= sprintf(
+                        '<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f" rx="2" ry="2" fill="%s" stroke="#000000" stroke-width="1"/>',
+                        $rowLeft + $ci * $pitch - $dot / 2, $gridTop + $ri * $pitch - $dot / 2, $dot, $dot,
+                        isset($bookedSeatIds[$seat->id]) ? '#000000' : '#ffffff'
+                    );
+                }
+            }
+        }
+
+        $scale = min(200 / $width, 90 / $height);
+
+        return sprintf(
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d" width="%smm" height="%smm">%s</svg>',
+            $width, $height, round($width * $scale, 1), round($height * $scale, 1), $svg
+        );
+    }
+}

--- a/app/Services/Svg/OrderCardSvgGenerator.php
+++ b/app/Services/Svg/OrderCardSvgGenerator.php
@@ -77,7 +77,7 @@ class OrderCardSvgGenerator
         [$path, $turnArrows] = $this->windingPath();
         $arrows = $this->arrows($turnArrows, $mpdf);
 
-        $scale = min(195 / $width, 125 / $height);
+        $scale = min(195 / $width, 105 / $height);
 
         return $this->svg->document($width, $height, $width * $scale, $height * $scale, $path.$boxes.$arrows);
     }

--- a/app/Services/Svg/OrderCardSvgGenerator.php
+++ b/app/Services/Svg/OrderCardSvgGenerator.php
@@ -147,35 +147,42 @@ class OrderCardSvgGenerator
         return $boxes;
     }
 
+    /** @return array<int,int> */
+    private function occupiedRows(): array
+    {
+        return array_values(array_filter(
+            range(0, $this->rowCount - 1),
+            fn ($ri) => $this->rows[$ri]->seats->count() > 0
+        ));
+    }
+
     /**
      * @return array{0: string, 1: array<int,array{0: float, 1: float, 2: string}>}
      */
     private function windingPath(): array
     {
-        $rowCount = $this->rowCount;
+        $occupied = $this->occupiedRows();
         $moves = [];        // ['L', x, y] or ['A', rx, ry, sweep, x, y]
         $turnArrows = [];
-        for ($ri = 0; $ri < $rowCount; $ri++) {
-            if ($this->rows[$ri]->seats->count() < 1) {
-                continue;
-            }
-            $ltr = $ri % 2 === 0;
+        foreach ($occupied as $k => $ri) {
+            $ltr = $k % 2 === 0;
             $y = $this->cy($ri);
             $startX = $ltr ? $this->cx($this->rowLeftCol($ri)) : $this->cx($this->rowRightCol($ri));
             $endX = $ltr ? $this->cx($this->rowRightCol($ri)) : $this->cx($this->rowLeftCol($ri));
+            $next = $occupied[$k + 1] ?? null;
 
             $turnX = $endX;
-            if ($ri < $rowCount - 1 && $this->rows[$ri + 1]->seats->count() > 0) {
-                $nextStartCol = $ltr ? $this->rowRightCol($ri + 1) : $this->rowLeftCol($ri + 1);
+            if ($next !== null) {
+                $nextStartCol = $ltr ? $this->rowRightCol($next) : $this->rowLeftCol($next);
                 $turnX = $ltr ? max($endX, $this->cx($nextStartCol)) : min($endX, $this->cx($nextStartCol));
             }
             $moves[] = ['L', $startX, $y];
             $moves[] = ['L', $turnX, $y];
 
-            if ($ri < $rowCount - 1) {
-                $nextY = $this->cy($ri + 1);
-                $nextLtr = ($ri + 1) % 2 === 0;
-                $nextEntryX = $nextLtr ? $this->cx($this->rowLeftCol($ri + 1)) : $this->cx($this->rowRightCol($ri + 1));
+            if ($next !== null) {
+                $nextY = $this->cy($next);
+                $nextLtr = ($k + 1) % 2 === 0;
+                $nextEntryX = $nextLtr ? $this->cx($this->rowLeftCol($next)) : $this->cx($this->rowRightCol($next));
                 $dir = $ltr ? 1 : -1;
                 $outX = $turnX + $dir * self::TURN;
 
@@ -186,13 +193,14 @@ class OrderCardSvgGenerator
             }
         }
 
-        $lastRi = $rowCount - 1;
-        if ($lastRi >= 0 && $this->rows[$lastRi]->seats->count() > 0) {
-            $endDir = $lastRi % 2 === 0 ? 1 : -1;
-            $rowEndX = $lastRi % 2 === 0 ? $this->cx($this->rowRightCol($lastRi)) : $this->cx($this->rowLeftCol($lastRi));
-            $endStubX = $rowEndX + $endDir * (self::BOX / 2 + 24);
+        if (! empty($occupied)) {
+            $lastK = count($occupied) - 1;
+            $lastRi = $occupied[$lastK];
+            $ltr = $lastK % 2 === 0;
+            $rowEndX = $ltr ? $this->cx($this->rowRightCol($lastRi)) : $this->cx($this->rowLeftCol($lastRi));
+            $endStubX = $rowEndX + ($ltr ? 1 : -1) * (self::BOX / 2 + 24);
             $moves[] = ['L', $endStubX, $this->cy($lastRi)];
-            $turnArrows[] = [$endStubX, $this->cy($lastRi), $lastRi % 2 === 0 ? 'right' : 'left'];
+            $turnArrows[] = [$endStubX, $this->cy($lastRi), $ltr ? 'right' : 'left'];
         }
 
         $path = empty($moves) ? '' : $this->svg->path($this->rotatedPathData($moves), 4);
@@ -245,15 +253,15 @@ class OrderCardSvgGenerator
     {
         $arrows = $this->startMarker($mpdf);
 
-        foreach ($this->rows as $ri => $row) {
-            $count = $row->seats->count();
+        foreach ($this->occupiedRows() as $k => $ri) {
+            $count = $this->rows[$ri]->seats->count();
             if ($count < 2) {
                 continue;
             }
             $g = (int) floor(($count - 1) / 2);
             $gapX = $this->cx($this->rowLeftCol($ri) + $g) + self::STRIDE / 2;
             [$mx, $my] = $this->place($gapX, $this->cy($ri));
-            $arrows .= $this->svg->arrowHead($mx, $my, $this->dir($ri % 2 === 0 ? 'right' : 'left'));
+            $arrows .= $this->svg->arrowHead($mx, $my, $this->dir($k % 2 === 0 ? 'right' : 'left'));
         }
         foreach ($turnArrows as [$tx, $ty, $tdir]) {
             [$px, $py] = $this->place($tx, $ty);
@@ -265,11 +273,12 @@ class OrderCardSvgGenerator
 
     private function startMarker(Mpdf $mpdf): string
     {
-        if ($this->rowCount === 0 || $this->rows[0]->seats->count() === 0) {
+        $first = $this->occupiedRows()[0] ?? null;
+        if ($first === null) {
             return '';
         }
 
-        [$bx, $byc] = $this->place($this->cx($this->rowOffset(0)), $this->cy(0));
+        [$bx, $byc] = $this->place($this->cx($this->rowOffset($first)), $this->cy($first));
         $entry = $this->dir('down');
         [$ox, $oy] = match ($entry) {
             'down' => [0, -1],

--- a/app/Services/Svg/OrderCardSvgGenerator.php
+++ b/app/Services/Svg/OrderCardSvgGenerator.php
@@ -3,6 +3,7 @@
 namespace App\Services\Svg;
 
 use App\Models\Block;
+use Mpdf\Mpdf;
 
 class OrderCardSvgGenerator
 {
@@ -11,10 +12,16 @@ class OrderCardSvgGenerator
     /**
      * Block preview for the order-card divider.
      *
-     * @param  array<int,bool>  $bookedSeatIds  Set of booked seat IDs (id => true).
+     * @param  array<int,bool>  $bookedSeatIds  Set of booked seat IDs (id => true); these
+     *                                          boxes are filled black.
+     * @param  array<int,bool>|null  $labelSeatIds  Set of seat IDs to label; defaults to
+     *                                              the booked set. Booked boxes get a white
+     *                                              label, unbooked ones a black label.
      */
-    public function render(Block $block, array $bookedSeatIds): string
+    public function render(Block $block, array $bookedSeatIds, Mpdf $mpdf, ?array $labelSeatIds = null): string
     {
+        $labelSeatIds ??= $bookedSeatIds;
+
         $rows = $block->rows->sortBy('order')->values();
         if ($rows->isEmpty()) {
             return '';
@@ -33,28 +40,48 @@ class OrderCardSvgGenerator
         $width = $left * 2 + $maxSeats * $stride - $gap;
         $height = $pad * 2 + $rowCount * $stride - $gap;
 
-        $cx = fn (int $col) => $left + $col * $stride + $box / 2;
+        $rowOffset = function (int $ri) use ($rows, $maxSeats) {
+            $count = $rows[$ri]->seats->count();
+            $slack = $maxSeats - $count;
+            if ($slack <= 0) {
+                return 0.0;
+            }
+
+            return match ($rows[$ri]->alignment ?? 'center') {
+                'left' => 0.0,
+                'right' => (float) $slack,
+                default => $slack / 2,
+            };
+        };
+
+        $cx = fn (float $col) => $left + $col * $stride + $box / 2;
         $cy = fn (int $ri) => $pad + $ri * $stride + $box / 2;
 
-        $unbooked = $booked = '';
+        $under = $over = '';
         foreach ($rows as $ri => $row) {
+            $off = $rowOffset($ri);
             foreach ($row->seats->sortBy('number')->values() as $col => $seat) {
-                $x = $left + $col * $stride;
+                $x = $left + ($col + $off) * $stride;
                 $y = $pad + $ri * $stride;
-                $rect = fn ($fill) => sprintf(
-                    '<rect x="%d" y="%d" width="%d" height="%d" rx="%d" ry="%d" fill="%s" stroke="#000000" stroke-width="2"/>',
-                    $x, $y, $box, $box, $radius, $radius, $fill
+                $isBooked = isset($bookedSeatIds[$seat->id]);
+                $rect = sprintf(
+                    '<rect x="%.1f" y="%.1f" width="%d" height="%d" rx="%d" ry="%d" fill="%s" stroke="#000000" stroke-width="2"/>',
+                    $x, $y, $box, $box, $radius, $radius, $isBooked ? '#000000' : 'none'
                 );
-                if (isset($bookedSeatIds[$seat->id])) {
-                    $booked .= $rect('#000000').sprintf(
-                        '<text x="%.1f" y="%.1f" fill="#ffffff" font-size="30" font-weight="bold" font-family="sans-serif" text-anchor="middle">%s</text>',
-                        $x + $box / 2, $y + $box / 2 + 11, e($seat->label)
+                if (isset($labelSeatIds[$seat->id])) {
+                    $sz = SvgUtilities::SIZE_SEAT_LABEL;
+                    $over .= $rect.$this->svg->centeredLabel(
+                        $mpdf, (string) $seat->label, $sz, $isBooked ? '#ffffff' : '#000000',
+                        $x + $box / 2, $y + $box / 2 + $sz * SvgUtilities::BASELINE_FACTOR, $box - 8
                     );
                 } else {
-                    $unbooked .= $rect('none');
+                    $under .= $rect;
                 }
             }
         }
+
+        $rowLeftCol = fn (int $r) => $rowOffset($r);
+        $rowRightCol = fn (int $r) => $rowOffset($r) + $rows[$r]->seats->count() - 1;
 
         $d = '';
         $turnArrows = [];
@@ -65,18 +92,28 @@ class OrderCardSvgGenerator
             }
             $ltr = $ri % 2 === 0;
             $y = $cy($ri);
-            $startX = $ltr ? $cx(0) : $cx($count - 1);
-            $endX = $ltr ? $cx($count - 1) : $cx(0);
-            $d .= sprintf('%s %.1f %.1f L %.1f %.1f ', $d === '' ? 'M' : 'L', $startX, $y, $endX, $y);
+            $startX = $ltr ? $cx($rowLeftCol($ri)) : $cx($rowRightCol($ri));
+            $endX = $ltr ? $cx($rowRightCol($ri)) : $cx($rowLeftCol($ri));
+
+            $turnX = $endX;
+            if ($ri < $rowCount - 1 && $rows[$ri + 1]->seats->count() > 0) {
+                $nextStartCol = $ltr ? $rowRightCol($ri + 1) : $rowLeftCol($ri + 1);
+                $turnX = $ltr
+                    ? max($endX, $cx($nextStartCol))
+                    : min($endX, $cx($nextStartCol));
+            }
+            $d .= sprintf('%s %.1f %.1f L %.1f %.1f ', $d === '' ? 'M' : 'L', $startX, $y, $turnX, $y);
 
             if ($ri < $rowCount - 1) {
                 $nextY = $cy($ri + 1);
+                $nextLtr = ($ri + 1) % 2 === 0;
+                $nextEntryX = $nextLtr ? $cx($rowLeftCol($ri + 1)) : $cx($rowRightCol($ri + 1));
                 $dir = $ltr ? 1 : -1;
-                $outX = $endX + $dir * $turn;
+                $outX = $turnX + $dir * $turn;
                 $sweep = $ltr ? 1 : 0;
                 $d .= sprintf('L %.1f %.1f A %.1f %.1f 0 0 %d %.1f %.1f L %.1f %.1f A %.1f %.1f 0 0 %d %.1f %.1f L %.1f %.1f ',
                     $outX - $dir * $cr, $y, $cr, $cr, $sweep, $outX, $y + $cr,
-                    $outX, $nextY - $cr, $cr, $cr, $sweep, $outX - $dir * $cr, $nextY, $endX, $nextY);
+                    $outX, $nextY - $cr, $cr, $cr, $sweep, $outX - $dir * $cr, $nextY, $nextEntryX, $nextY);
                 $flatX = $outX - $dir * $cr - $dir * 6;
                 $turnArrows[] = [$flatX, $y, $ltr ? 'right' : 'left'];
                 $turnArrows[] = [$flatX, $nextY, $ltr ? 'left' : 'right'];
@@ -86,9 +123,8 @@ class OrderCardSvgGenerator
         $endStubX = null;
         $lastRi = $rowCount - 1;
         if ($lastRi >= 0 && $rows[$lastRi]->seats->count() > 0) {
-            $count = $rows[$lastRi]->seats->count();
             $endDir = $lastRi % 2 === 0 ? 1 : -1;
-            $rowEndX = $lastRi % 2 === 0 ? $cx($count - 1) : $cx(0);
+            $rowEndX = $lastRi % 2 === 0 ? $cx($rowRightCol($lastRi)) : $cx($rowLeftCol($lastRi));
             $endStubX = $rowEndX + $endDir * ($box / 2 + 24);
             $d .= sprintf('L %.1f %.1f ', $endStubX, $cy($lastRi));
         }
@@ -96,18 +132,21 @@ class OrderCardSvgGenerator
 
         $arrows = '';
         if ($rowCount > 0 && $rows[0]->seats->count() > 0) {
-            $sx = $cx(0);
+            $sx = $cx($rowOffset(0));
             $labelY = $cy(0) - $box / 2 - 26;
-            $arrows .= sprintf('<text x="%.1f" y="%.1f" fill="#000000" font-size="22" font-weight="bold" font-family="sans-serif" text-anchor="middle">START</text>', $sx, $labelY);
+            $arrows .= $this->svg->centeredLabel($mpdf, 'START', SvgUtilities::SIZE_START_LABEL, '#000000', $sx, $labelY, $stride * 3);
             $arrows .= sprintf('<line x1="%.1f" y1="%.1f" x2="%.1f" y2="%.1f" stroke="#000000" stroke-width="4"/>', $sx, $labelY + 6, $sx, $cy(0) - $box / 2 + 2);
             $arrows .= $this->svg->arrowHead($sx, $cy(0) - $box / 2 + 4, 'down');
         }
         foreach ($rows as $ri => $row) {
-            if ($row->seats->count() < 1) {
+            $count = $row->seats->count();
+            if ($count < 2) {
                 continue;
             }
-            $mx = $cx((int) floor(($maxSeats - 1) / 2)) + $stride / 2;
-            $arrows .= $this->svg->arrowHead($mx, $cy($ri), $ri % 2 === 0 ? 'right' : 'left');
+            $ltr = $ri % 2 === 0;
+            $g = (int) floor(($count - 1) / 2);
+            $gapX = $cx($rowLeftCol($ri) + $g) + $stride / 2;
+            $arrows .= $this->svg->arrowHead($gapX, $cy($ri), $ltr ? 'right' : 'left');
         }
         foreach ($turnArrows as [$tx, $ty, $tdir]) {
             $arrows .= $this->svg->arrowHead($tx, $ty, $tdir);
@@ -116,9 +155,13 @@ class OrderCardSvgGenerator
             $arrows .= $this->svg->arrowHead($endStubX, $cy($lastRi), $lastRi % 2 === 0 ? 'right' : 'left');
         }
 
+        $maxW = 195;
+        $maxH = 105;
+        $scale = min($maxW / $width, $maxH / $height);
+
         return sprintf(
-            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d" style="width:100%%;height:auto;">%s%s%s%s</svg>',
-            $width, $height, $unbooked, $path, $booked, $arrows
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d" width="%smm" height="%smm">%s%s%s%s</svg>',
+            $width, $height, round($width * $scale, 1), round($height * $scale, 1), $under, $path, $over, $arrows
         );
     }
 }

--- a/app/Services/Svg/OrderCardSvgGenerator.php
+++ b/app/Services/Svg/OrderCardSvgGenerator.php
@@ -3,165 +3,207 @@
 namespace App\Services\Svg;
 
 use App\Models\Block;
+use Illuminate\Support\Collection;
 use Mpdf\Mpdf;
 
 class OrderCardSvgGenerator
 {
+    private const BOX = 64;
+
+    private const GAP = 12;
+
+    private const PAD = 46;
+
+    private const TURN = 80;        // reach of the rounded u turns past a row edge
+
+    private const RADIUS = 12;      // seat-box corner radius
+
+    private const CORNER = 18;      // u turn corner radius
+
+    private const STRIDE = self::BOX + self::GAP;
+
+    /** @var Collection Rows of the block being rendered, sorted by order. */
+    private Collection $rows;
+
+    private int $maxSeats;
+
+    private float $left;
+
     public function __construct(private SvgUtilities $svg) {}
 
     /**
      * Block preview for the order-card divider.
      *
-     * @param  array<int,bool>  $bookedSeatIds  Set of booked seat IDs (id => true); these
-     *                                          boxes are filled black.
-     * @param  array<int,bool>|null  $labelSeatIds  Set of seat IDs to label; defaults to
-     *                                              the booked set. Booked boxes get a white
-     *                                              label, unbooked ones a black label.
+     * @param  array<int,bool>  $bookedSeatIds  Set of booked seat IDs.
      */
-    public function render(Block $block, array $bookedSeatIds, Mpdf $mpdf, ?array $labelSeatIds = null): string
+    public function render(Block $block, array $bookedSeatIds, Mpdf $mpdf): string
     {
-        $labelSeatIds ??= $bookedSeatIds;
-
-        $rows = $block->rows->sortBy('order')->values();
-        if ($rows->isEmpty()) {
+        $this->rows = $block->rows->sortBy('order')->values();
+        if ($this->rows->isEmpty()) {
             return '';
         }
 
-        $box = 64;
-        $gap = 12;
-        $pad = 46;
-        $turn = 80;   // reach of the rounded u turns past a row edge
-        $radius = 12;
-        $cr = 18;     // u turn corner radius
-        $stride = $box + $gap;
-        $rowCount = $rows->count();
-        $maxSeats = max((int) $rows->max(fn ($r) => $r->seats->count()), 1);
-        $left = $pad + $turn;
-        $width = $left * 2 + $maxSeats * $stride - $gap;
-        $height = $pad * 2 + $rowCount * $stride - $gap;
+        $rowCount = $this->rows->count();
+        $this->maxSeats = max((int) $this->rows->max(fn ($r) => $r->seats->count()), 1);
+        $this->left = self::PAD + self::TURN;
+        $width = $this->left * 2 + $this->maxSeats * self::STRIDE - self::GAP;
+        $height = self::PAD * 2 + $rowCount * self::STRIDE - self::GAP;
 
-        $rowOffset = function (int $ri) use ($rows, $maxSeats) {
-            $count = $rows[$ri]->seats->count();
-            $slack = $maxSeats - $count;
-            if ($slack <= 0) {
-                return 0.0;
-            }
+        [$under, $over] = $this->seatBoxes($bookedSeatIds, $mpdf);
+        [$path, $turnArrows] = $this->windingPath($rowCount);
+        $arrows = $this->arrows($rowCount, $turnArrows, $mpdf);
 
-            return match ($rows[$ri]->alignment ?? 'center') {
-                'left' => 0.0,
-                'right' => (float) $slack,
-                default => $slack / 2,
-            };
+        $scale = min(195 / $width, 125 / $height);
+
+        return $this->svg->document($width, $height, $width * $scale, $height * $scale, $under.$path.$over.$arrows);
+    }
+
+    /** Seat center x for a column. */
+    private function cx(float $col): float
+    {
+        return $this->left + $col * self::STRIDE + self::BOX / 2;
+    }
+
+    /** Seat center y for a row. */
+    private function cy(int $ri): float
+    {
+        return self::PAD + $ri * self::STRIDE + self::BOX / 2;
+    }
+
+    private function rowOffset(int $ri): float
+    {
+        $slack = $this->maxSeats - $this->rows[$ri]->seats->count();
+
+        return match ($slack > 0 ? ($this->rows[$ri]->alignment ?? 'center') : 'left') {
+            'right' => (float) $slack,
+            'center' => $slack / 2,
+            default => 0.0,
         };
+    }
 
-        $cx = fn (float $col) => $left + $col * $stride + $box / 2;
-        $cy = fn (int $ri) => $pad + $ri * $stride + $box / 2;
+    private function rowLeftCol(int $ri): float
+    {
+        return $this->rowOffset($ri);
+    }
 
+    private function rowRightCol(int $ri): float
+    {
+        return $this->rowOffset($ri) + $this->rows[$ri]->seats->count() - 1;
+    }
+
+    private function seatBoxes(array $bookedSeatIds, Mpdf $mpdf): array
+    {
+        $sz = SvgUtilities::SIZE_SEAT_LABEL;
         $under = $over = '';
-        foreach ($rows as $ri => $row) {
-            $off = $rowOffset($ri);
+        foreach ($this->rows as $ri => $row) {
+            $off = $this->rowOffset($ri);
             foreach ($row->seats->sortBy('number')->values() as $col => $seat) {
-                $x = $left + ($col + $off) * $stride;
-                $y = $pad + $ri * $stride;
+                $x = $this->left + ($col + $off) * self::STRIDE;
+                $y = self::PAD + $ri * self::STRIDE;
                 $isBooked = isset($bookedSeatIds[$seat->id]);
-                $rect = sprintf(
-                    '<rect x="%.1f" y="%.1f" width="%d" height="%d" rx="%d" ry="%d" fill="%s" stroke="#000000" stroke-width="2"/>',
-                    $x, $y, $box, $box, $radius, $radius, $isBooked ? '#000000' : 'none'
-                );
-                if (isset($labelSeatIds[$seat->id])) {
-                    $sz = SvgUtilities::SIZE_SEAT_LABEL;
-                    $over .= $rect.$this->svg->centeredLabel(
+                $box = $this->svg->rect($x, $y, self::BOX, self::BOX, $isBooked ? '#000000' : '#ffffff', 2, self::RADIUS)
+                    .$this->svg->centeredLabelX(
                         $mpdf, (string) $seat->label, $sz, $isBooked ? '#ffffff' : '#000000',
-                        $x + $box / 2, $y + $box / 2 + $sz * SvgUtilities::BASELINE_FACTOR, $box - 8
+                        $x + self::BOX / 2, $y + self::BOX / 2 + $sz * SvgUtilities::BASELINE_FACTOR, self::BOX - 8
                     );
+                if ($isBooked) {
+                    $over .= $box;
                 } else {
-                    $under .= $rect;
+                    $under .= $box;
                 }
             }
         }
 
-        $rowLeftCol = fn (int $r) => $rowOffset($r);
-        $rowRightCol = fn (int $r) => $rowOffset($r) + $rows[$r]->seats->count() - 1;
+        return [$under, $over];
+    }
 
+    /**
+     * @return array{0: string, 1: array<int,array{0: float, 1: float, 2: string}>}
+     */
+    private function windingPath(int $rowCount): array
+    {
         $d = '';
         $turnArrows = [];
         for ($ri = 0; $ri < $rowCount; $ri++) {
-            $count = $rows[$ri]->seats->count();
-            if ($count < 1) {
+            if ($this->rows[$ri]->seats->count() < 1) {
                 continue;
             }
             $ltr = $ri % 2 === 0;
-            $y = $cy($ri);
-            $startX = $ltr ? $cx($rowLeftCol($ri)) : $cx($rowRightCol($ri));
-            $endX = $ltr ? $cx($rowRightCol($ri)) : $cx($rowLeftCol($ri));
+            $y = $this->cy($ri);
+            $startX = $ltr ? $this->cx($this->rowLeftCol($ri)) : $this->cx($this->rowRightCol($ri));
+            $endX = $ltr ? $this->cx($this->rowRightCol($ri)) : $this->cx($this->rowLeftCol($ri));
 
             $turnX = $endX;
-            if ($ri < $rowCount - 1 && $rows[$ri + 1]->seats->count() > 0) {
-                $nextStartCol = $ltr ? $rowRightCol($ri + 1) : $rowLeftCol($ri + 1);
-                $turnX = $ltr
-                    ? max($endX, $cx($nextStartCol))
-                    : min($endX, $cx($nextStartCol));
+            if ($ri < $rowCount - 1 && $this->rows[$ri + 1]->seats->count() > 0) {
+                $nextStartCol = $ltr ? $this->rowRightCol($ri + 1) : $this->rowLeftCol($ri + 1);
+                $turnX = $ltr ? max($endX, $this->cx($nextStartCol)) : min($endX, $this->cx($nextStartCol));
             }
             $d .= sprintf('%s %.1f %.1f L %.1f %.1f ', $d === '' ? 'M' : 'L', $startX, $y, $turnX, $y);
 
             if ($ri < $rowCount - 1) {
-                $nextY = $cy($ri + 1);
+                $nextY = $this->cy($ri + 1);
                 $nextLtr = ($ri + 1) % 2 === 0;
-                $nextEntryX = $nextLtr ? $cx($rowLeftCol($ri + 1)) : $cx($rowRightCol($ri + 1));
+                $nextEntryX = $nextLtr ? $this->cx($this->rowLeftCol($ri + 1)) : $this->cx($this->rowRightCol($ri + 1));
                 $dir = $ltr ? 1 : -1;
-                $outX = $turnX + $dir * $turn;
-                $sweep = $ltr ? 1 : 0;
-                $d .= sprintf('L %.1f %.1f A %.1f %.1f 0 0 %d %.1f %.1f L %.1f %.1f A %.1f %.1f 0 0 %d %.1f %.1f L %.1f %.1f ',
-                    $outX - $dir * $cr, $y, $cr, $cr, $sweep, $outX, $y + $cr,
-                    $outX, $nextY - $cr, $cr, $cr, $sweep, $outX - $dir * $cr, $nextY, $nextEntryX, $nextY);
-                $flatX = $outX - $dir * $cr - $dir * 6;
+                $outX = $turnX + $dir * self::TURN;
+
+                $d .= $this->uTurn($y, $nextEntryX, $nextY, $outX, $dir, $ltr);
+                $flatX = $outX - $dir * self::CORNER - $dir * 6;
                 $turnArrows[] = [$flatX, $y, $ltr ? 'right' : 'left'];
                 $turnArrows[] = [$flatX, $nextY, $ltr ? 'left' : 'right'];
             }
         }
 
-        $endStubX = null;
         $lastRi = $rowCount - 1;
-        if ($lastRi >= 0 && $rows[$lastRi]->seats->count() > 0) {
+        if ($lastRi >= 0 && $this->rows[$lastRi]->seats->count() > 0) {
             $endDir = $lastRi % 2 === 0 ? 1 : -1;
-            $rowEndX = $lastRi % 2 === 0 ? $cx($rowRightCol($lastRi)) : $cx($rowLeftCol($lastRi));
-            $endStubX = $rowEndX + $endDir * ($box / 2 + 24);
-            $d .= sprintf('L %.1f %.1f ', $endStubX, $cy($lastRi));
+            $rowEndX = $lastRi % 2 === 0 ? $this->cx($this->rowRightCol($lastRi)) : $this->cx($this->rowLeftCol($lastRi));
+            $endStubX = $rowEndX + $endDir * (self::BOX / 2 + 24);
+            $d .= sprintf('L %.1f %.1f ', $endStubX, $this->cy($lastRi));
+            $turnArrows[] = [$endStubX, $this->cy($lastRi), $lastRi % 2 === 0 ? 'right' : 'left'];
         }
-        $path = $d === '' ? '' : sprintf('<path d="%s" fill="none" stroke="#000000" stroke-width="4"/>', trim($d));
 
+        $path = $d === '' ? '' : $this->svg->path(trim($d), 4);
+
+        return [$path, $turnArrows];
+    }
+
+    private function uTurn(float $y, float $nextEntryX, float $nextY, float $outX, int $dir, bool $ltr): string
+    {
+        $cr = self::CORNER;
+        $sweep = $ltr ? 1 : 0;
+
+        return sprintf('L %.1f %.1f A %.1f %.1f 0 0 %d %.1f %.1f L %.1f %.1f A %.1f %.1f 0 0 %d %.1f %.1f L %.1f %.1f ',
+            $outX - $dir * $cr, $y, $cr, $cr, $sweep, $outX, $y + $cr,
+            $outX, $nextY - $cr, $cr, $cr, $sweep, $outX - $dir * $cr, $nextY, $nextEntryX, $nextY);
+    }
+
+    /**
+     * @param  array<int,array{0: float, 1: float, 2: string}>  $turnArrows
+     */
+    private function arrows(int $rowCount, array $turnArrows, Mpdf $mpdf): string
+    {
         $arrows = '';
-        if ($rowCount > 0 && $rows[0]->seats->count() > 0) {
-            $sx = $cx($rowOffset(0));
-            $labelY = $cy(0) - $box / 2 - 26;
-            $arrows .= $this->svg->centeredLabel($mpdf, 'START', SvgUtilities::SIZE_START_LABEL, '#000000', $sx, $labelY, $stride * 3);
-            $arrows .= sprintf('<line x1="%.1f" y1="%.1f" x2="%.1f" y2="%.1f" stroke="#000000" stroke-width="4"/>', $sx, $labelY + 6, $sx, $cy(0) - $box / 2 + 2);
-            $arrows .= $this->svg->arrowHead($sx, $cy(0) - $box / 2 + 4, 'down');
+        if ($rowCount > 0 && $this->rows[0]->seats->count() > 0) {
+            $sx = $this->cx($this->rowOffset(0));
+            $labelY = $this->cy(0) - self::BOX / 2 - 26;
+            $arrows .= $this->svg->centeredLabelX($mpdf, 'START', SvgUtilities::SIZE_START_LABEL, '#000000', $sx, $labelY, self::STRIDE * 3);
+            $arrows .= $this->svg->line($sx, $labelY + 6, $sx, $this->cy(0) - self::BOX / 2 + 2, 4);
+            $arrows .= $this->svg->arrowHead($sx, $this->cy(0) - self::BOX / 2 + 4, 'down');
         }
-        foreach ($rows as $ri => $row) {
+        foreach ($this->rows as $ri => $row) {
             $count = $row->seats->count();
             if ($count < 2) {
                 continue;
             }
-            $ltr = $ri % 2 === 0;
             $g = (int) floor(($count - 1) / 2);
-            $gapX = $cx($rowLeftCol($ri) + $g) + $stride / 2;
-            $arrows .= $this->svg->arrowHead($gapX, $cy($ri), $ltr ? 'right' : 'left');
+            $gapX = $this->cx($this->rowLeftCol($ri) + $g) + self::STRIDE / 2;
+            $arrows .= $this->svg->arrowHead($gapX, $this->cy($ri), $ri % 2 === 0 ? 'right' : 'left');
         }
         foreach ($turnArrows as [$tx, $ty, $tdir]) {
             $arrows .= $this->svg->arrowHead($tx, $ty, $tdir);
         }
-        if ($endStubX !== null) {
-            $arrows .= $this->svg->arrowHead($endStubX, $cy($lastRi), $lastRi % 2 === 0 ? 'right' : 'left');
-        }
 
-        $maxW = 195;
-        $maxH = 105;
-        $scale = min($maxW / $width, $maxH / $height);
-
-        return sprintf(
-            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d" width="%smm" height="%smm">%s%s%s%s</svg>',
-            $width, $height, round($width * $scale, 1), round($height * $scale, 1), $under, $path, $over, $arrows
-        );
+        return $arrows;
     }
 }

--- a/app/Services/Svg/OrderCardSvgGenerator.php
+++ b/app/Services/Svg/OrderCardSvgGenerator.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Services\Svg;
+
+use App\Models\Block;
+
+class OrderCardSvgGenerator
+{
+    public function __construct(private SvgUtilities $svg) {}
+
+    /**
+     * Block preview for the order-card divider.
+     *
+     * @param  array<int,bool>  $bookedSeatIds  Set of booked seat IDs (id => true).
+     */
+    public function render(Block $block, array $bookedSeatIds): string
+    {
+        $rows = $block->rows->sortBy('order')->values();
+        if ($rows->isEmpty()) {
+            return '';
+        }
+
+        $box = 64;
+        $gap = 12;
+        $pad = 46;
+        $turn = 80;   // reach of the rounded u turns past a row edge
+        $radius = 12;
+        $cr = 18;     // u turn corner radius
+        $stride = $box + $gap;
+        $rowCount = $rows->count();
+        $maxSeats = max((int) $rows->max(fn ($r) => $r->seats->count()), 1);
+        $left = $pad + $turn;
+        $width = $left * 2 + $maxSeats * $stride - $gap;
+        $height = $pad * 2 + $rowCount * $stride - $gap;
+
+        $cx = fn (int $col) => $left + $col * $stride + $box / 2;
+        $cy = fn (int $ri) => $pad + $ri * $stride + $box / 2;
+
+        $unbooked = $booked = '';
+        foreach ($rows as $ri => $row) {
+            foreach ($row->seats->sortBy('number')->values() as $col => $seat) {
+                $x = $left + $col * $stride;
+                $y = $pad + $ri * $stride;
+                $rect = fn ($fill) => sprintf(
+                    '<rect x="%d" y="%d" width="%d" height="%d" rx="%d" ry="%d" fill="%s" stroke="#000000" stroke-width="2"/>',
+                    $x, $y, $box, $box, $radius, $radius, $fill
+                );
+                if (isset($bookedSeatIds[$seat->id])) {
+                    $booked .= $rect('#000000').sprintf(
+                        '<text x="%.1f" y="%.1f" fill="#ffffff" font-size="30" font-weight="bold" font-family="sans-serif" text-anchor="middle">%s</text>',
+                        $x + $box / 2, $y + $box / 2 + 11, e($seat->label)
+                    );
+                } else {
+                    $unbooked .= $rect('none');
+                }
+            }
+        }
+
+        $d = '';
+        $turnArrows = [];
+        for ($ri = 0; $ri < $rowCount; $ri++) {
+            $count = $rows[$ri]->seats->count();
+            if ($count < 1) {
+                continue;
+            }
+            $ltr = $ri % 2 === 0;
+            $y = $cy($ri);
+            $startX = $ltr ? $cx(0) : $cx($count - 1);
+            $endX = $ltr ? $cx($count - 1) : $cx(0);
+            $d .= sprintf('%s %.1f %.1f L %.1f %.1f ', $d === '' ? 'M' : 'L', $startX, $y, $endX, $y);
+
+            if ($ri < $rowCount - 1) {
+                $nextY = $cy($ri + 1);
+                $dir = $ltr ? 1 : -1;
+                $outX = $endX + $dir * $turn;
+                $sweep = $ltr ? 1 : 0;
+                $d .= sprintf('L %.1f %.1f A %.1f %.1f 0 0 %d %.1f %.1f L %.1f %.1f A %.1f %.1f 0 0 %d %.1f %.1f L %.1f %.1f ',
+                    $outX - $dir * $cr, $y, $cr, $cr, $sweep, $outX, $y + $cr,
+                    $outX, $nextY - $cr, $cr, $cr, $sweep, $outX - $dir * $cr, $nextY, $endX, $nextY);
+                $flatX = $outX - $dir * $cr - $dir * 6;
+                $turnArrows[] = [$flatX, $y, $ltr ? 'right' : 'left'];
+                $turnArrows[] = [$flatX, $nextY, $ltr ? 'left' : 'right'];
+            }
+        }
+
+        $endStubX = null;
+        $lastRi = $rowCount - 1;
+        if ($lastRi >= 0 && $rows[$lastRi]->seats->count() > 0) {
+            $count = $rows[$lastRi]->seats->count();
+            $endDir = $lastRi % 2 === 0 ? 1 : -1;
+            $rowEndX = $lastRi % 2 === 0 ? $cx($count - 1) : $cx(0);
+            $endStubX = $rowEndX + $endDir * ($box / 2 + 24);
+            $d .= sprintf('L %.1f %.1f ', $endStubX, $cy($lastRi));
+        }
+        $path = $d === '' ? '' : sprintf('<path d="%s" fill="none" stroke="#000000" stroke-width="4"/>', trim($d));
+
+        $arrows = '';
+        if ($rowCount > 0 && $rows[0]->seats->count() > 0) {
+            $sx = $cx(0);
+            $labelY = $cy(0) - $box / 2 - 26;
+            $arrows .= sprintf('<text x="%.1f" y="%.1f" fill="#000000" font-size="22" font-weight="bold" font-family="sans-serif" text-anchor="middle">START</text>', $sx, $labelY);
+            $arrows .= sprintf('<line x1="%.1f" y1="%.1f" x2="%.1f" y2="%.1f" stroke="#000000" stroke-width="4"/>', $sx, $labelY + 6, $sx, $cy(0) - $box / 2 + 2);
+            $arrows .= $this->svg->arrowHead($sx, $cy(0) - $box / 2 + 4, 'down');
+        }
+        foreach ($rows as $ri => $row) {
+            if ($row->seats->count() < 1) {
+                continue;
+            }
+            $mx = $cx((int) floor(($maxSeats - 1) / 2)) + $stride / 2;
+            $arrows .= $this->svg->arrowHead($mx, $cy($ri), $ri % 2 === 0 ? 'right' : 'left');
+        }
+        foreach ($turnArrows as [$tx, $ty, $tdir]) {
+            $arrows .= $this->svg->arrowHead($tx, $ty, $tdir);
+        }
+        if ($endStubX !== null) {
+            $arrows .= $this->svg->arrowHead($endStubX, $cy($lastRi), $lastRi % 2 === 0 ? 'right' : 'left');
+        }
+
+        return sprintf(
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d" style="width:100%%;height:auto;">%s%s%s%s</svg>',
+            $width, $height, $unbooked, $path, $booked, $arrows
+        );
+    }
+}

--- a/app/Services/Svg/OrderCardSvgGenerator.php
+++ b/app/Services/Svg/OrderCardSvgGenerator.php
@@ -20,6 +20,8 @@ class OrderCardSvgGenerator
 
     private const CORNER = 18;      // u turn corner radius
 
+    private const START_STEM = 52;  // box edge to label: arrow gap + stem + a little
+
     private const STRIDE = self::BOX + self::GAP;
 
     /** @var Collection Rows of the block being rendered, sorted by order. */
@@ -27,7 +29,17 @@ class OrderCardSvgGenerator
 
     private int $maxSeats;
 
+    private int $rowCount;
+
+    private int $rotation = 0;
+
     private float $left;
+
+    private float $seatSpan;
+
+    private float $rowSpan;
+
+    private float $rowTop;
 
     public function __construct(private SvgUtilities $svg) {}
 
@@ -43,19 +55,31 @@ class OrderCardSvgGenerator
             return '';
         }
 
-        $rowCount = $this->rows->count();
+        $this->rotation = (int) ($block->rotation ?? 0);
+        $this->rowCount = $this->rows->count();
         $this->maxSeats = max((int) $this->rows->max(fn ($r) => $r->seats->count()), 1);
         $this->left = self::PAD + self::TURN;
-        $width = $this->left * 2 + $this->maxSeats * self::STRIDE - self::GAP;
-        $height = self::PAD * 2 + $rowCount * self::STRIDE - self::GAP;
 
-        [$under, $over] = $this->seatBoxes($bookedSeatIds, $mpdf);
-        [$path, $turnArrows] = $this->windingPath($rowCount);
-        $arrows = $this->arrows($rowCount, $turnArrows, $mpdf);
+        $this->rowTop = match ($this->rotation) {
+            0 => self::PAD,
+            180 => self::PAD + self::START_STEM,
+            default => self::PAD + self::START_STEM + $this->svg->textWidth($mpdf, 'START', SvgUtilities::SIZE_START_LABEL),
+        };
+
+        $this->seatSpan = $this->left * 2 + $this->maxSeats * self::STRIDE - self::GAP;
+        $this->rowSpan = $this->rowTop + self::PAD + $this->rowCount * self::STRIDE - self::GAP;
+
+        $vertical = $this->rotation === 90 || $this->rotation === 270;
+        $width = $vertical ? $this->rowSpan : $this->seatSpan;
+        $height = $vertical ? $this->seatSpan : $this->rowSpan;
+
+        $boxes = $this->seatBoxes($bookedSeatIds, $mpdf);
+        [$path, $turnArrows] = $this->windingPath();
+        $arrows = $this->arrows($turnArrows, $mpdf);
 
         $scale = min(195 / $width, 125 / $height);
 
-        return $this->svg->document($width, $height, $width * $scale, $height * $scale, $under.$path.$over.$arrows);
+        return $this->svg->document($width, $height, $width * $scale, $height * $scale, $path.$boxes.$arrows);
     }
 
     /** Seat center x for a column. */
@@ -65,9 +89,19 @@ class OrderCardSvgGenerator
     }
 
     /** Seat center y for a row. */
-    private function cy(int $ri): float
+    private function cy(float $ri): float
     {
-        return self::PAD + $ri * self::STRIDE + self::BOX / 2;
+        return $this->rowTop + $ri * self::STRIDE + self::BOX / 2;
+    }
+
+    private function place(float $x, float $y): array
+    {
+        return match ($this->rotation) {
+            90 => [$this->rowSpan - $y, $x],
+            180 => [$this->seatSpan - $x, $this->rowSpan - $y],
+            270 => [$y, $this->seatSpan - $x],
+            default => [$x, $y],
+        };
     }
 
     private function rowOffset(int $ri): float
@@ -91,38 +125,35 @@ class OrderCardSvgGenerator
         return $this->rowOffset($ri) + $this->rows[$ri]->seats->count() - 1;
     }
 
-    private function seatBoxes(array $bookedSeatIds, Mpdf $mpdf): array
+    private function seatBoxes(array $bookedSeatIds, Mpdf $mpdf): string
     {
         $sz = SvgUtilities::SIZE_SEAT_LABEL;
-        $under = $over = '';
+        $boxes = '';
         foreach ($this->rows as $ri => $row) {
             $off = $this->rowOffset($ri);
             foreach ($row->seats->sortBy('number')->values() as $col => $seat) {
-                $x = $this->left + ($col + $off) * self::STRIDE;
-                $y = self::PAD + $ri * self::STRIDE;
+                [$cxp, $cyp] = $this->place($this->cx($col + $off), $this->cy($ri));
+                $x = $cxp - self::BOX / 2;
+                $y = $cyp - self::BOX / 2;
                 $isBooked = isset($bookedSeatIds[$seat->id]);
-                $box = $this->svg->rect($x, $y, self::BOX, self::BOX, $isBooked ? '#000000' : '#ffffff', 2, self::RADIUS)
+                $boxes .= $this->svg->rect($x, $y, self::BOX, self::BOX, $isBooked ? '#000000' : '#ffffff', 2, self::RADIUS)
                     .$this->svg->centeredLabelX(
                         $mpdf, (string) $seat->label, $sz, $isBooked ? '#ffffff' : '#000000',
-                        $x + self::BOX / 2, $y + self::BOX / 2 + $sz * SvgUtilities::BASELINE_FACTOR, self::BOX - 8
+                        $cxp, $cyp + $sz * SvgUtilities::BASELINE_FACTOR, self::BOX - 8
                     );
-                if ($isBooked) {
-                    $over .= $box;
-                } else {
-                    $under .= $box;
-                }
             }
         }
 
-        return [$under, $over];
+        return $boxes;
     }
 
     /**
      * @return array{0: string, 1: array<int,array{0: float, 1: float, 2: string}>}
      */
-    private function windingPath(int $rowCount): array
+    private function windingPath(): array
     {
-        $d = '';
+        $rowCount = $this->rowCount;
+        $moves = [];        // ['L', x, y] or ['A', rx, ry, sweep, x, y]
         $turnArrows = [];
         for ($ri = 0; $ri < $rowCount; $ri++) {
             if ($this->rows[$ri]->seats->count() < 1) {
@@ -138,7 +169,8 @@ class OrderCardSvgGenerator
                 $nextStartCol = $ltr ? $this->rowRightCol($ri + 1) : $this->rowLeftCol($ri + 1);
                 $turnX = $ltr ? max($endX, $this->cx($nextStartCol)) : min($endX, $this->cx($nextStartCol));
             }
-            $d .= sprintf('%s %.1f %.1f L %.1f %.1f ', $d === '' ? 'M' : 'L', $startX, $y, $turnX, $y);
+            $moves[] = ['L', $startX, $y];
+            $moves[] = ['L', $turnX, $y];
 
             if ($ri < $rowCount - 1) {
                 $nextY = $this->cy($ri + 1);
@@ -147,7 +179,7 @@ class OrderCardSvgGenerator
                 $dir = $ltr ? 1 : -1;
                 $outX = $turnX + $dir * self::TURN;
 
-                $d .= $this->uTurn($y, $nextEntryX, $nextY, $outX, $dir, $ltr);
+                array_push($moves, ...$this->uTurn($y, $nextEntryX, $nextY, $outX, $dir, $ltr));
                 $flatX = $outX - $dir * self::CORNER - $dir * 6;
                 $turnArrows[] = [$flatX, $y, $ltr ? 'right' : 'left'];
                 $turnArrows[] = [$flatX, $nextY, $ltr ? 'left' : 'right'];
@@ -159,38 +191,60 @@ class OrderCardSvgGenerator
             $endDir = $lastRi % 2 === 0 ? 1 : -1;
             $rowEndX = $lastRi % 2 === 0 ? $this->cx($this->rowRightCol($lastRi)) : $this->cx($this->rowLeftCol($lastRi));
             $endStubX = $rowEndX + $endDir * (self::BOX / 2 + 24);
-            $d .= sprintf('L %.1f %.1f ', $endStubX, $this->cy($lastRi));
+            $moves[] = ['L', $endStubX, $this->cy($lastRi)];
             $turnArrows[] = [$endStubX, $this->cy($lastRi), $lastRi % 2 === 0 ? 'right' : 'left'];
         }
 
-        $path = $d === '' ? '' : $this->svg->path(trim($d), 4);
+        $path = empty($moves) ? '' : $this->svg->path($this->rotatedPathData($moves), 4);
 
         return [$path, $turnArrows];
     }
 
-    private function uTurn(float $y, float $nextEntryX, float $nextY, float $outX, int $dir, bool $ltr): string
+    /**
+     * @return array<int,array<int|float|string>>
+     */
+    private function uTurn(float $y, float $nextEntryX, float $nextY, float $outX, int $dir, bool $ltr): array
     {
         $cr = self::CORNER;
         $sweep = $ltr ? 1 : 0;
 
-        return sprintf('L %.1f %.1f A %.1f %.1f 0 0 %d %.1f %.1f L %.1f %.1f A %.1f %.1f 0 0 %d %.1f %.1f L %.1f %.1f ',
-            $outX - $dir * $cr, $y, $cr, $cr, $sweep, $outX, $y + $cr,
-            $outX, $nextY - $cr, $cr, $cr, $sweep, $outX - $dir * $cr, $nextY, $nextEntryX, $nextY);
+        return [
+            ['L', $outX - $dir * $cr, $y],
+            ['A', $cr, $cr, $sweep, $outX, $y + $cr],
+            ['L', $outX, $nextY - $cr],
+            ['A', $cr, $cr, $sweep, $outX - $dir * $cr, $nextY],
+            ['L', $nextEntryX, $nextY],
+        ];
+    }
+
+    /**
+     * @param  array<int,array<int|float|string>>  $moves
+     */
+    private function rotatedPathData(array $moves): string
+    {
+        $d = '';
+        foreach ($moves as $i => $m) {
+            if ($m[0] === 'A') {
+                [, $rx, $ry, $sweep, $x, $y] = $m;
+                [$px, $py] = $this->place($x, $y);
+                $d .= sprintf('A %.1f %.1f 0 0 %d %.1f %.1f ', $rx, $ry, $sweep, $px, $py);
+            } else {
+                [, $x, $y] = $m;
+                [$px, $py] = $this->place($x, $y);
+                $d .= sprintf('%s %.1f %.1f ', $i === 0 ? 'M' : 'L', $px, $py);
+            }
+        }
+
+        return trim($d);
     }
 
     /**
      * @param  array<int,array{0: float, 1: float, 2: string}>  $turnArrows
      */
-    private function arrows(int $rowCount, array $turnArrows, Mpdf $mpdf): string
+    private function arrows(array $turnArrows, Mpdf $mpdf): string
     {
-        $arrows = '';
-        if ($rowCount > 0 && $this->rows[0]->seats->count() > 0) {
-            $sx = $this->cx($this->rowOffset(0));
-            $labelY = $this->cy(0) - self::BOX / 2 - 26;
-            $arrows .= $this->svg->centeredLabelX($mpdf, 'START', SvgUtilities::SIZE_START_LABEL, '#000000', $sx, $labelY, self::STRIDE * 3);
-            $arrows .= $this->svg->line($sx, $labelY + 6, $sx, $this->cy(0) - self::BOX / 2 + 2, 4);
-            $arrows .= $this->svg->arrowHead($sx, $this->cy(0) - self::BOX / 2 + 4, 'down');
-        }
+        $arrows = $this->startMarker($mpdf);
+
         foreach ($this->rows as $ri => $row) {
             $count = $row->seats->count();
             if ($count < 2) {
@@ -198,12 +252,57 @@ class OrderCardSvgGenerator
             }
             $g = (int) floor(($count - 1) / 2);
             $gapX = $this->cx($this->rowLeftCol($ri) + $g) + self::STRIDE / 2;
-            $arrows .= $this->svg->arrowHead($gapX, $this->cy($ri), $ri % 2 === 0 ? 'right' : 'left');
+            [$mx, $my] = $this->place($gapX, $this->cy($ri));
+            $arrows .= $this->svg->arrowHead($mx, $my, $this->dir($ri % 2 === 0 ? 'right' : 'left'));
         }
         foreach ($turnArrows as [$tx, $ty, $tdir]) {
-            $arrows .= $this->svg->arrowHead($tx, $ty, $tdir);
+            [$px, $py] = $this->place($tx, $ty);
+            $arrows .= $this->svg->arrowHead($px, $py, $this->dir($tdir));
         }
 
         return $arrows;
+    }
+
+    private function startMarker(Mpdf $mpdf): string
+    {
+        if ($this->rowCount === 0 || $this->rows[0]->seats->count() === 0) {
+            return '';
+        }
+
+        [$bx, $byc] = $this->place($this->cx($this->rowOffset(0)), $this->cy(0));
+        $entry = $this->dir('down');
+        [$ox, $oy] = match ($entry) {
+            'down' => [0, -1],
+            'up' => [0, 1],
+            'left' => [1, 0],
+            'right' => [-1, 0],
+        };
+        $edge = self::BOX / 2;
+        $sz = SvgUtilities::SIZE_START_LABEL;
+        $tipX = $bx + $ox * ($edge + 8);
+        $tipY = $byc + $oy * ($edge + 8);
+        $stemX = $bx + $ox * ($edge + 30);
+        $stemY = $byc + $oy * ($edge + 30);
+
+        $labelOut = $edge + 38 + ($ox !== 0 ? $this->svg->textWidth($mpdf, 'START', $sz) / 2 : 0);
+        $drop = $this->rotation === 180 ? 12 : 0;
+        $labelX = $bx + $ox * $labelOut;
+        $labelY = $byc + $oy * $labelOut + $sz * SvgUtilities::BASELINE_FACTOR + $drop;
+
+        return $this->svg->line($stemX, $stemY, $tipX, $tipY, 4)
+            .$this->svg->arrowHead($tipX, $tipY, $entry)
+            .$this->svg->centeredLabelX($mpdf, 'START', $sz, '#000000', $labelX, $labelY, self::STRIDE * 3);
+    }
+
+    private function dir(string $direction): string
+    {
+        if ($this->rotation === 0) {
+            return $direction;
+        }
+        $ring = ['right', 'down', 'left', 'up'];
+        $steps = intdiv($this->rotation, 90);
+        $i = array_search($direction, $ring, true);
+
+        return $ring[($i + $steps) % 4];
     }
 }

--- a/app/Services/Svg/SvgUtilities.php
+++ b/app/Services/Svg/SvgUtilities.php
@@ -10,14 +10,19 @@ class SvgUtilities
 
     public const FONT_STYLE = '';
 
-    public const SIZE_SEAT_LABEL = 30;      // order-card seat letters
-    public const SIZE_START_LABEL = 22;     // order-card START marker
-    public const SIZE_STAGE_LABEL = 24;     // master-overview stage cell
-    public const SIZE_BLOCK_LABEL = 20;     // master-overview block name
+    public const SIZE_SEAT_LABEL = 30; // order-card
+
+    public const SIZE_START_LABEL = 22; // order-card
+
+    public const SIZE_STAGE_LABEL = 24; // master-card
+
+    public const SIZE_BLOCK_LABEL = 20; // master-card
 
     public const BASELINE_FACTOR = 0.35;
 
-    public function centeredLabel(Mpdf $mpdf, string $text, float $preferredSize, string $color, float $centerX, float $baselineY, float $maxWidth): string
+    private const STROKE = '#000000';
+
+    public function centeredLabelX(Mpdf $mpdf, string $text, float $preferredSize, string $color, float $centerX, float $baselineY, float $maxWidth): string
     {
         $size = $preferredSize;
         $width = $this->textWidth($mpdf, $text, $size);
@@ -36,12 +41,44 @@ class SvgUtilities
 
     public function textWidth(Mpdf $mpdf, string $text, float $fontSize): float
     {
-        [$f, $s, $sz] = [$mpdf->FontFamily, $mpdf->FontStyle, $mpdf->FontSizePt];
-        $mpdf->SetFont(self::FONT_FAMILY ?: $f, self::FONT_STYLE, $fontSize, false);
+        [$family, $style, $sizePt] = [$mpdf->FontFamily, $mpdf->FontStyle, $mpdf->FontSizePt];
+
+        $mpdf->SetFont(self::FONT_FAMILY ?: $family, self::FONT_STYLE, $fontSize, false);
         $widthMm = $mpdf->GetStringWidth($text);
-        $mpdf->SetFont($f, $s, $sz, false);
+        $mpdf->SetFont($family, $style, $sizePt, false);
 
         return $widthMm * 72 / 25.4;
+    }
+
+    public function document(float $viewW, float $viewH, float $widthMm, float $heightMm, string $body): string
+    {
+        return sprintf(
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d" width="%smm" height="%smm">%s</svg>',
+            $viewW, $viewH, round($widthMm, 1), round($heightMm, 1), $body
+        );
+    }
+
+    public function rect(float $x, float $y, float $w, float $h, string $fill, float $strokeWidth, float $rx = 0): string
+    {
+        $corners = $rx > 0 ? sprintf(' rx="%.1f" ry="%.1f"', $rx, $rx) : '';
+
+        return sprintf(
+            '<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f"%s fill="%s" stroke="%s" stroke-width="%.1f"/>',
+            $x, $y, $w, $h, $corners, $fill, self::STROKE, $strokeWidth
+        );
+    }
+
+    public function line(float $x1, float $y1, float $x2, float $y2, float $strokeWidth): string
+    {
+        return sprintf(
+            '<line x1="%.1f" y1="%.1f" x2="%.1f" y2="%.1f" stroke="%s" stroke-width="%.1f"/>',
+            $x1, $y1, $x2, $y2, self::STROKE, $strokeWidth
+        );
+    }
+
+    public function path(string $d, float $strokeWidth): string
+    {
+        return sprintf('<path d="%s" fill="none" stroke="%s" stroke-width="%.1f"/>', $d, self::STROKE, $strokeWidth);
     }
 
     public function arrowHead(float $x, float $y, string $direction): string

--- a/app/Services/Svg/SvgUtilities.php
+++ b/app/Services/Svg/SvgUtilities.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Services\Svg;
+
+use Mpdf\Mpdf;
+
+class SvgUtilities
+{
+    public function centeredLabel(Mpdf $mpdf, string $text, float $preferredSize, string $color, float $centerX, float $baselineY, float $maxWidth): string
+    {
+        $size = $preferredSize;
+        $width = $this->textWidth($mpdf, $text, $size);
+        if ($width > $maxWidth && $width > 0) {
+            $size = max($preferredSize * ($maxWidth / $width), 6.0);
+            $width = $this->textWidth($mpdf, $text, $size);
+        }
+
+        return sprintf(
+            '<text x="%.1f" y="%.1f" fill="%s" font-size="%.1f" font-family="orbitron" text-anchor="start">%s</text>',
+            $centerX - $width / 2, $baselineY, $color, $size, e($text)
+        );
+    }
+
+    public function textWidth(Mpdf $mpdf, string $text, float $fontSize): float
+    {
+        [$f, $s, $sz] = [$mpdf->FontFamily, $mpdf->FontStyle, $mpdf->FontSizePt];
+        $mpdf->SetFont('orbitron', '', $fontSize, false);
+        $widthMm = $mpdf->GetStringWidth($text);
+        $mpdf->SetFont($f, $s, $sz, false);
+
+        return $widthMm * 72 / 25.4;
+    }
+
+    public function arrowHead(float $x, float $y, string $direction): string
+    {
+        $s = 14;
+        [$tip, $a, $b] = match ($direction) {
+            'right' => [[$x + $s, $y], [$x - $s * 0.6, $y - $s], [$x - $s * 0.6, $y + $s]],
+            'left' => [[$x - $s, $y], [$x + $s * 0.6, $y - $s], [$x + $s * 0.6, $y + $s]],
+            'down' => [[$x, $y + $s], [$x - $s, $y - $s * 0.6], [$x + $s, $y - $s * 0.6]],
+            'up' => [[$x, $y - $s], [$x - $s, $y + $s * 0.6], [$x + $s, $y + $s * 0.6]],
+        };
+
+        return sprintf(
+            '<polygon points="%.1f,%.1f %.1f,%.1f %.1f,%.1f" fill="#000000" stroke="#ffffff" stroke-width="1.5"/>',
+            $tip[0], $tip[1], $a[0], $a[1], $b[0], $b[1]
+        );
+    }
+}

--- a/app/Services/Svg/SvgUtilities.php
+++ b/app/Services/Svg/SvgUtilities.php
@@ -6,6 +6,17 @@ use Mpdf\Mpdf;
 
 class SvgUtilities
 {
+    public const FONT_FAMILY = '';
+
+    public const FONT_STYLE = '';
+
+    public const SIZE_SEAT_LABEL = 30;      // order-card seat letters
+    public const SIZE_START_LABEL = 22;     // order-card START marker
+    public const SIZE_STAGE_LABEL = 24;     // master-overview stage cell
+    public const SIZE_BLOCK_LABEL = 20;     // master-overview block name
+
+    public const BASELINE_FACTOR = 0.35;
+
     public function centeredLabel(Mpdf $mpdf, string $text, float $preferredSize, string $color, float $centerX, float $baselineY, float $maxWidth): string
     {
         $size = $preferredSize;
@@ -15,16 +26,18 @@ class SvgUtilities
             $width = $this->textWidth($mpdf, $text, $size);
         }
 
+        $family = self::FONT_FAMILY !== '' ? sprintf(' font-family="%s"', self::FONT_FAMILY) : '';
+
         return sprintf(
-            '<text x="%.1f" y="%.1f" fill="%s" font-size="%.1f" font-family="orbitron" text-anchor="start">%s</text>',
-            $centerX - $width / 2, $baselineY, $color, $size, e($text)
+            '<text x="%.1f" y="%.1f" fill="%s" font-size="%.1f"%s text-anchor="start">%s</text>',
+            $centerX - $width / 2, $baselineY, $color, $size, $family, e($text)
         );
     }
 
     public function textWidth(Mpdf $mpdf, string $text, float $fontSize): float
     {
         [$f, $s, $sz] = [$mpdf->FontFamily, $mpdf->FontStyle, $mpdf->FontSizePt];
-        $mpdf->SetFont('orbitron', '', $fontSize, false);
+        $mpdf->SetFont(self::FONT_FAMILY ?: $f, self::FONT_STYLE, $fontSize, false);
         $widthMm = $mpdf->GetStringWidth($text);
         $mpdf->SetFont($f, $s, $sz, false);
 

--- a/app/Services/Svg/SvgUtilities.php
+++ b/app/Services/Svg/SvgUtilities.php
@@ -10,7 +10,7 @@ class SvgUtilities
 
     public const FONT_STYLE = '';
 
-    public const SIZE_SEAT_LABEL = 30; // order-card
+    public const SIZE_SEAT_LABEL = 48; // order-card
 
     public const SIZE_START_LABEL = 22; // order-card
 

--- a/resources/views/pdf/card-layout.blade.php
+++ b/resources/views/pdf/card-layout.blade.php
@@ -57,7 +57,8 @@
             font-size: 40pt;
             font-weight: bold;
             color: #000;
-            margin-bottom: 3mm;
+            margin-top: 15mm;
+            margin-bottom: 4mm;
             width: 80%;
             margin-left: auto;
             margin-right: auto;

--- a/resources/views/pdf/card-layout.blade.php
+++ b/resources/views/pdf/card-layout.blade.php
@@ -59,7 +59,7 @@
             font-size: 40pt;
             font-weight: bold;
             color: #000;
-            margin-bottom: 4mm;
+            margin-bottom: 3mm;
             width: 80%;
             margin-left: auto;
             margin-right: auto;
@@ -74,7 +74,7 @@
             font-size: 60pt;
             font-weight: bold;
             color: #000;
-            margin-bottom: 8mm;
+            margin-bottom: 5mm;
             width: 80%;
             margin-left: auto;
             margin-right: auto;
@@ -99,10 +99,6 @@
             width: 72%;
             margin: 0 auto;
             text-align: center;
-        }
-
-        .block-preview svg {
-            max-height: 110mm;
         }
 
         .master-overview {
@@ -135,7 +131,7 @@
         @yield('styles')
     </style>
 </head>
-<body class="@yield('bodyClass')">
+<body>
     <div class="card-content">
         @yield('content')
     </div>

--- a/resources/views/pdf/card-layout.blade.php
+++ b/resources/views/pdf/card-layout.blade.php
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        /* Orbitron font is handled by mPDF configuration */
+
+        body {
+            font-family: 'zhurzh', 'DejaVu Sans', sans-serif;
+            margin: 0;
+            padding: 0;
+            width: 297mm;
+            height: 210mm;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            text-align: center;
+
+        }
+
+        .card-content {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            width: 100%;
+            height: 100%;
+            background-image: url('file://{{ resource_path('/assets/images/seating_card.png')  }}');
+            background-size: contain;
+            background-repeat: no-repeat;
+            background-position: center center;
+        }
+
+        .text-content {
+            padding-top: 43mm;
+            text-align: center;
+        }
+
+        .card-name {
+            font-family: 'zhurzh', 'DejaVu Sans', sans-serif;
+            font-size: 80pt;
+            font-weight: bold;
+            color: #000;
+            margin-top: 15mm;
+            margin-bottom: 5mm;
+            width: 75%;
+            margin-left: auto;
+            margin-right: auto;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            word-wrap: break-word;
+            line-height: 1.2;
+        }
+
+        /* Order-card divider headings */
+        .event-name {
+            font-family: 'zhurzh', 'DejaVu Sans', sans-serif;
+            font-size: 40pt;
+            font-weight: bold;
+            color: #000;
+            margin-bottom: 4mm;
+            width: 80%;
+            margin-left: auto;
+            margin-right: auto;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            word-wrap: break-word;
+            line-height: 1.1;
+        }
+
+        .block-name {
+            font-family: 'zhurzh', 'DejaVu Sans', sans-serif;
+            font-size: 60pt;
+            font-weight: bold;
+            color: #000;
+            margin-bottom: 8mm;
+            width: 80%;
+            margin-left: auto;
+            margin-right: auto;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            word-wrap: break-word;
+            line-height: 1.1;
+        }
+
+        .card-location {
+            font-family: 'zhurzh', 'DejaVu Sans', sans-serif;
+            font-size: 32pt;
+            font-weight: normal;
+            color: #000;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            line-height: 1.6;
+            display: flex;
+        }
+
+        .block-preview {
+            width: 72%;
+            margin: 0 auto;
+            text-align: center;
+        }
+
+        .block-preview svg {
+            max-height: 110mm;
+        }
+
+        .master-overview {
+            width: 100%;
+            text-align: center;
+        }
+
+        .master-overview svg {
+            display: inline-block;
+        }
+
+        .not-picked-up {
+            font-family: 'zhurzh', 'DejaVu Sans', sans-serif;
+            font-size: 28pt;
+            font-weight: bold;
+            color: #ffffff;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            background-color: #000;
+            padding: 4mm 10mm;
+            white-space: nowrap;
+        }
+
+        .not-picked-up-wrapper {
+            position: fixed;
+            bottom: 20mm;
+            right: 20mm;
+        }
+
+        @yield('styles')
+    </style>
+</head>
+<body class="@yield('bodyClass')">
+    <div class="card-content">
+        @yield('content')
+    </div>
+    @yield('overlay')
+</body>
+</html>

--- a/resources/views/pdf/card-layout.blade.php
+++ b/resources/views/pdf/card-layout.blade.php
@@ -3,8 +3,6 @@
 <head>
     <meta charset="utf-8">
     <style>
-        /* Orbitron font is handled by mPDF configuration */
-
         body {
             font-family: 'zhurzh', 'DejaVu Sans', sans-serif;
             margin: 0;

--- a/resources/views/pdf/master-page.blade.php
+++ b/resources/views/pdf/master-page.blade.php
@@ -1,7 +1,5 @@
 @extends('pdf.card-layout')
 
-@section('bodyClass', 'master-page')
-
 @section('styles')
     .event-name { font-size: 52pt; margin-top: 0; margin-bottom: 2mm; }
     .block-name { font-size: 26pt; margin-bottom: 6mm; }

--- a/resources/views/pdf/master-page.blade.php
+++ b/resources/views/pdf/master-page.blade.php
@@ -1,0 +1,31 @@
+@extends('pdf.card-layout')
+
+@section('bodyClass', 'master-page')
+
+@section('styles')
+    .event-name { font-size: 52pt; margin-top: 0; margin-bottom: 2mm; }
+    .block-name { font-size: 26pt; margin-bottom: 6mm; }
+@endsection
+
+@section('content')
+    <div class="text-content">
+        <div class="event-name">
+            @if($event_name)
+                {{ $event_name }}
+            @else
+                Unknown
+            @endif
+        </div>
+        <div class="block-name">
+            Layout
+        </div>
+        @if(!empty($overview))
+            <div class="block-preview master-overview">
+                {!! $overview !!}
+            </div>
+        @endif
+    </div>
+@endsection
+
+@section('overlay')
+@endsection

--- a/resources/views/pdf/master-page.blade.php
+++ b/resources/views/pdf/master-page.blade.php
@@ -1,8 +1,8 @@
 @extends('pdf.card-layout')
 
 @section('styles')
-    .event-name { font-size: 52pt; margin-top: 0; margin-bottom: 2mm; }
-    .block-name { font-size: 26pt; margin-bottom: 6mm; }
+    .event-name { font-size: 52pt; margin-top: 0.2em; margin-bottom: 1mm; }
+    .block-name { font-size: 26pt; margin-bottom: 3mm; }
 @endsection
 
 @section('content')

--- a/resources/views/pdf/order-card.blade.php
+++ b/resources/views/pdf/order-card.blade.php
@@ -1,0 +1,28 @@
+@extends('pdf.card-layout')
+
+@section('content')
+    <div class="text-content">
+        <div class="event-name">
+            @if($info->event_name)
+                {{ $info->event_name }}
+            @else
+                Unknown
+            @endif
+        </div>
+        <div class="block-name">
+            @if($info->block_name)
+                {{ $info->block_name }}
+            @else
+                Unknown
+            @endif
+        </div>
+        @if(!empty($preview))
+            <div class="block-preview">
+                {!! $preview !!}
+            </div>
+        @endif
+    </div>
+@endsection
+
+@section('overlay')
+@endsection

--- a/resources/views/pdf/order-card.blade.php
+++ b/resources/views/pdf/order-card.blade.php
@@ -1,5 +1,11 @@
 @extends('pdf.card-layout')
 
+@section('styles')
+    .text-content { padding-top: 24mm; }
+    .event-name { margin-bottom: 2mm; }
+    .block-name { font-size: 52pt; margin-bottom: 4mm; }
+@endsection
+
 @section('content')
     <div class="text-content">
         <div class="event-name">

--- a/resources/views/pdf/order-card.blade.php
+++ b/resources/views/pdf/order-card.blade.php
@@ -2,8 +2,8 @@
 
 @section('styles')
     .text-content { padding-top: 24mm; }
-    .event-name { margin-bottom: 2mm; }
-    .block-name { font-size: 52pt; margin-bottom: 4mm; }
+    .event-name { margin-bottom: 2mm; margin-top: 22mm; }
+    .block-name { font-size: 52pt; margin-bottom: 2mm; }
 @endsection
 
 @section('content')

--- a/resources/views/pdf/seating-card-single.blade.php
+++ b/resources/views/pdf/seating-card-single.blade.php
@@ -1,105 +1,23 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <style>
-        /* Zhurzh font is handled by mPDF configuration */
+@extends('pdf.card-layout')
 
-        body {
-            font-family: 'zhurzh', 'DejaVu Sans', sans-serif;
-            margin: 0;
-            padding: 0;
-            width: 297mm;
-            height: 210mm;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            text-align: center;
-
-        }
-
-        .card-content {
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            width: 100%;
-            height: 100%;
-            background-image: url('file://{{ resource_path('/assets/images/seating_card.png')  }}');
-            background-size: contain;
-            background-repeat: no-repeat;
-            background-position: center center;
-        }
-
-        .text-content {
-            padding-top: 43mm;
-            text-align: center;
-        }
-
-        .card-name {
-            font-family: 'zhurzh', 'DejaVu Sans', sans-serif;
-            font-size: 80pt;
-            font-weight: bold;
-            color: #000;
-            margin-top: 15mm;
-            margin-bottom: 5mm;
-            width: 75%;
-            margin-left: auto;
-            margin-right: auto;
-            text-transform: uppercase;
-            letter-spacing: 2px;
-            word-wrap: break-word;
-            line-height: 1.2;
-        }
-
-        .card-location {
-            font-family: 'zhurzh', 'DejaVu Sans', sans-serif;
-            font-size: 32pt;
-            font-weight: normal;
-            color: #000;
-            text-transform: uppercase;
-            letter-spacing: 1px;
-            line-height: 1.6;
-            display: flex;
-        }
-
-        .not-picked-up {
-            font-family: 'zhurzh', 'DejaVu Sans', sans-serif;
-            font-size: 28pt;
-            font-weight: bold;
-            color: #ffffff;
-            text-transform: uppercase;
-            letter-spacing: 2px;
-            background-color: #000;
-            padding: 4mm 10mm;
-            white-space: nowrap;
-        }
-
-        .not-picked-up-wrapper {
-            position: fixed;
-            bottom: 20mm;
-            right: 20mm;
-        }
-    </style>
-</head>
-<body>
-    <div class="card-content">
-        <div class="text-content">
-            <div class="card-name">
-                @if($booking->name)
-                    {{ Str::limit($booking->name, 24, '') }}
-                @elseif($booking->user)
-                    {{ Str::limit($booking->user->name, 24, '') }}
-                @else
-                    Unknown
-                @endif
-            </div>
-            <div class="card-location">
-                Block {{ $booking->seat->row->block->name }} {{ $booking->seat->row->name }} Seat {{ $booking->seat->label }}
-            </div>
+@section('content')
+    <div class="text-content">
+        <div class="card-name">
+            @if($booking->name)
+                {{ Str::limit($booking->name, 24, '') }}
+            @elseif($booking->user)
+                {{ Str::limit($booking->user->name, 24, '') }}
+            @else
+                Unknown
+            @endif
+        </div>
+        <div class="card-location">
+            Block {{ $booking->seat->row->block->name }} {{ $booking->seat->row->name }} Seat {{ $booking->seat->label }}
         </div>
     </div>
+@endsection
+
+@section('overlay')
     @if(is_null($booking->picked_up_at))
     <div class="not-picked-up-wrapper">
         <table style="border-collapse: collapse; width: 1px;">
@@ -107,5 +25,4 @@
         </table>
     </div>
     @endif
-</body>
-</html>
+@endsection


### PR DESCRIPTION
The sort sorts it so it goes from block to block top to donw, left to right, then row per row, except for each other row it reverses, so the runners placing the seat cards can easier place them without having to walk to the start of the row

And the block cards help with splitting it for the different runners, and the master card helps with splitting it per event,

<img width="947" height="670" alt="Screenshot 2026-07-18 at 11 56 26" src="https://github.com/user-attachments/assets/a5d406cf-c049-4772-a3e6-c6b2c40e8ba7" />
<img width="944" height="669" alt="Screenshot 2026-07-18 at 11 56 33" src="https://github.com/user-attachments/assets/819b0c67-d0a0-41d9-bf71-9b5a558c95fd" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added SVG-based PDF generation for event master overviews, order cards, and seating cards.
  * Introduced shared PDF card templates and dedicated layouts for master and order/seating views.

* **Improvements**
  * Updated the seating-card placement ordering for more consistent card layout.
  * Revised PDF creation to render a clear sequence of pages (overview → per-block order cards → individual seating cards), improving preview and distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

This fixes #26 