### PR TITLE
Add entrance and comment blocks

### DIFF
--- a/app/Http/Controllers/Admin/EventAdminController.php
+++ b/app/Http/Controllers/Admin/EventAdminController.php
@@ -120,6 +120,10 @@ class EventAdminController extends Controller
             ->orderBy('order')
             ->get();
 
+        $markerBlocks = $room->markerBlocks()
+            ->select('id', 'room_id', 'name', 'type', 'position_x', 'position_y', 'rotation', 'order')
+            ->get();
+
         // Only load essential block data for the seat layout
         $blocks = $room->blocks()
             ->select('id', 'room_id', 'name', 'position_x', 'position_y', 'rotation', 'order')
@@ -200,6 +204,7 @@ class EventAdminController extends Controller
             'room' => $room,
             'blocks' => $blocks,
             'stageBlocks' => $stageBlocks,
+            'markerBlocks' => $markerBlocks,
             'bookings' => $bookings,
             'bookedSeats' => $bookedSeats,
             'seatBookingMap' => $seatBookingMap,
@@ -358,6 +363,9 @@ class EventAdminController extends Controller
             $masterStageBlocks = $room->stageBlocks()
                 ->select('id', 'room_id', 'name', 'position_x', 'position_y')
                 ->get();
+            $masterMarkerBlocks = $room->markerBlocks()
+                ->select('id', 'room_id', 'name', 'type', 'position_x', 'position_y', 'rotation')
+                ->get();
 
             // mPDF configuration with custom Zhurzh font
             $mpdf = new \Mpdf\Mpdf([
@@ -389,7 +397,7 @@ class EventAdminController extends Controller
             $pages[] = view('pdf.master-page', [
                 'event_name' => $event->name,
                 'room_name' => $room->name,
-                'overview' => $masterCard->render($masterBlocks, $masterStageBlocks, $bookedSeatIds, $mpdf),
+                'overview' => $masterCard->render($masterBlocks, $masterStageBlocks, $masterMarkerBlocks, $bookedSeatIds, $mpdf),
             ])->render();
 
             $currentBlockId = null;

--- a/app/Http/Controllers/Admin/RoomLayoutController.php
+++ b/app/Http/Controllers/Admin/RoomLayoutController.php
@@ -117,66 +117,27 @@ class RoomLayoutController extends Controller
         $blockIdMap = [];
 
         DB::transaction(function () use ($request, $room, &$blockIdMap) {
-            // Update stage blocks
-            $existingStageBlockIds = $room->stageBlocks()->pluck('id')->toArray();
-            $submittedStageBlocks = $request->stageBlocks ?? [];
-            $submittedStageBlockIds = collect($submittedStageBlocks)->pluck('id')->filter()->toArray();
-
-            // Delete stage blocks that are no longer in the submission
-            $stageBlocksToDelete = array_diff($existingStageBlockIds, $submittedStageBlockIds);
-            if (! empty($stageBlocksToDelete)) {
-                $room->stageBlocks()->whereIn('id', $stageBlocksToDelete)->delete();
-            }
-
-            // Update or create stage blocks
-            foreach ($submittedStageBlocks as $index => $stageBlockData) {
-                if ($stageBlockData['id']) {
-                    // Update existing stage block
-                    $room->stageBlocks()->where('id', $stageBlockData['id'])->update([
-                        'name' => $stageBlockData['name'],
-                        'position_x' => $stageBlockData['position_x'],
-                        'position_y' => $stageBlockData['position_y'],
-                        'order' => $index,
-                    ]);
-                } else {
-                    // Create new stage block
-                    $room->allBlocks()->create([
-                        'name' => $stageBlockData['name'],
-                        'type' => 'stage',
-                        'position_x' => $stageBlockData['position_x'],
-                        'position_y' => $stageBlockData['position_y'],
-                        'rotation' => 0,
-                        'order' => $index,
-                    ]);
-                }
-            }
-
-            // Update marker blocks
-            $existingMarkerBlockIds = $room->markerBlocks()->pluck('id')->toArray();
-            $submittedMarkerBlocks = $request->markerBlocks ?? [];
-            $submittedMarkerBlockIds = collect($submittedMarkerBlocks)->pluck('id')->filter()->toArray();
-
-            $markerBlocksToDelete = array_diff($existingMarkerBlockIds, $submittedMarkerBlockIds);
-            if (! empty($markerBlocksToDelete)) {
-                $room->markerBlocks()->whereIn('id', $markerBlocksToDelete)->delete();
-            }
-
-            foreach ($submittedMarkerBlocks as $index => $markerBlockData) {
-                $attributes = [
-                    'name' => $markerBlockData['name'],
-                    'type' => $markerBlockData['type'],
-                    'position_x' => $markerBlockData['position_x'],
-                    'position_y' => $markerBlockData['position_y'],
-                    'rotation' => $markerBlockData['rotation'] ?? 0,
+            $this->reconcileBlocks($room, $room->stageBlocks(), $request->stageBlocks ?? [], function ($data, $index) {
+                return [
+                    'name' => $data['name'],
+                    'type' => 'stage',
+                    'position_x' => $data['position_x'],
+                    'position_y' => $data['position_y'],
+                    'rotation' => 0,
                     'order' => $index,
                 ];
+            });
 
-                if ($markerBlockData['id']) {
-                    $room->markerBlocks()->where('id', $markerBlockData['id'])->update($attributes);
-                } else {
-                    $room->allBlocks()->create($attributes);
-                }
-            }
+            $this->reconcileBlocks($room, $room->markerBlocks(), $request->markerBlocks ?? [], function ($data, $index) {
+                return [
+                    'name' => $data['name'],
+                    'type' => $data['type'],
+                    'position_x' => $data['position_x'],
+                    'position_y' => $data['position_y'],
+                    'rotation' => $data['rotation'] ?? 0,
+                    'order' => $index,
+                ];
+            });
 
             $nextBlockOrder = ($room->blocks()->max('order') ?? -1) + 1;
 
@@ -278,6 +239,32 @@ class RoomLayoutController extends Controller
         $block->delete();
 
         return back()->with('success', 'Block deleted successfully!');
+    }
+
+    /**
+     * Delete blocks in $scope absent from $submitted, then update-or-create the rest.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\HasMany  $scope
+     * @param  array<int,array<string,mixed>>  $submitted
+     */
+    private function reconcileBlocks(Room $room, $scope, array $submitted, callable $attributes): void
+    {
+        $submittedIds = collect($submitted)->pluck('id')->filter()->all();
+        $toDelete = array_diff($scope->clone()->pluck('id')->all(), $submittedIds);
+
+        if (! empty($toDelete)) {
+            $scope->clone()->whereIn('id', $toDelete)->delete();
+        }
+
+        foreach ($submitted as $index => $data) {
+            $values = $attributes($data, $index);
+
+            if ($data['id']) {
+                $scope->clone()->where('id', $data['id'])->update($values);
+            } else {
+                $room->allBlocks()->create($values);
+            }
+        }
     }
 
     private function numberToLetter(int $number): string

--- a/app/Http/Controllers/Admin/RoomLayoutController.php
+++ b/app/Http/Controllers/Admin/RoomLayoutController.php
@@ -7,7 +7,6 @@ use App\Models\Booking;
 use App\Models\Room;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 
 class RoomLayoutController extends Controller
@@ -76,33 +75,43 @@ class RoomLayoutController extends Controller
 
     public function update(Request $request, Room $room)
     {
-        $roomBlockIds = $room->blocks()->pluck('id')->all();
+        $ownedId = fn ($scope, string $message) => function (string $_attribute, $value, $fail) use ($scope, $message) {
+            if ($value === null || (is_string($value) && str_starts_with($value, 'temp-'))) {
+                return;
+            }
+            if (! $scope->clone()->where('id', $value)->exists()) {
+                $fail($message);
+            }
+        };
 
         $request->validate([
             'stageBlocks' => 'sometimes|array',
-            'stageBlocks.*.id' => ['nullable', Rule::in($room->stageBlocks()->pluck('id')->all())],
+            'stageBlocks.*.id' => ['nullable', $ownedId($room->stageBlocks(), 'The selected stage block id is invalid for this room.')],
             'stageBlocks.*.name' => 'required|string|max:255',
             'stageBlocks.*.position_x' => 'required|integer|min:-1',
             'stageBlocks.*.position_y' => 'required|integer|min:-1',
             'markerBlocks' => 'sometimes|array',
-            'markerBlocks.*.id' => ['nullable', Rule::in($room->markerBlocks()->pluck('id')->all())],
+            'markerBlocks.*.id' => ['nullable', $ownedId($room->markerBlocks(), 'The selected marker block id is invalid for this room.')],
             'markerBlocks.*.type' => 'required|string|in:entrance,comment',
             'markerBlocks.*.name' => 'required|string|max:255',
-            'markerBlocks.*.position_x' => 'required|integer|min:-1',
-            'markerBlocks.*.position_y' => 'required|integer|min:-1',
+            'markerBlocks.*.position_x' => ['required', 'integer', 'min:-1', 'max:11'],
+            'markerBlocks.*.position_y' => ['required', 'integer', 'min:-1', 'max:7'],
             'markerBlocks.*.rotation' => 'nullable|integer|in:0,90,180,270',
-            'blocks' => 'required|array',
-            'blocks.*.id' => [
-                'required',
-                function (string $attribute, $value, $fail) use ($roomBlockIds) {
-                    $isTempId = is_string($value) && str_starts_with($value, 'temp-');
-                    $isExistingRoomBlock = is_numeric($value) && in_array((int) $value, $roomBlockIds, true);
-
-                    if (! $isTempId && ! $isExistingRoomBlock) {
-                        $fail('The selected block id is invalid for this room.');
+            'markerBlocks.*' => [
+                function (string $attribute, $value, $fail) {
+                    $type = $value['type'] ?? null;
+                    $x = isset($value['position_x']) ? (int) $value['position_x'] : null;
+                    $y = isset($value['position_y']) ? (int) $value['position_y'] : null;
+                    if ($type === 'comment' && ($x === -1 || $y === -1)) {
+                        $fail('Comment markers must have valid grid coordinates.');
+                    }
+                    if ($type === 'entrance' && $x === -1 && $y === -1) {
+                        $fail('Entrance markers must be placed on a row or column.');
                     }
                 },
             ],
+            'blocks' => 'required|array',
+            'blocks.*.id' => ['required', $ownedId($room->blocks(), 'The selected block id is invalid for this room.')],
             'blocks.*.name' => 'required|string|max:255',
             'blocks.*.position_x' => 'required|integer|min:-1',
             'blocks.*.position_y' => 'required|integer|min:-1',
@@ -117,27 +126,31 @@ class RoomLayoutController extends Controller
         $blockIdMap = [];
 
         DB::transaction(function () use ($request, $room, &$blockIdMap) {
-            $this->reconcileBlocks($room, $room->stageBlocks(), $request->stageBlocks ?? [], function ($data, $index) {
-                return [
-                    'name' => $data['name'],
-                    'type' => 'stage',
-                    'position_x' => $data['position_x'],
-                    'position_y' => $data['position_y'],
-                    'rotation' => 0,
-                    'order' => $index,
-                ];
-            });
+            if ($request->has('stageBlocks')) {
+                $this->reconcileBlocks($room, $room->stageBlocks(), $request->stageBlocks, function ($data, $index) {
+                    return [
+                        'name' => $data['name'],
+                        'type' => 'stage',
+                        'position_x' => $data['position_x'],
+                        'position_y' => $data['position_y'],
+                        'rotation' => 0,
+                        'order' => $index,
+                    ];
+                });
+            }
 
-            $this->reconcileBlocks($room, $room->markerBlocks(), $request->markerBlocks ?? [], function ($data, $index) {
-                return [
-                    'name' => $data['name'],
-                    'type' => $data['type'],
-                    'position_x' => $data['position_x'],
-                    'position_y' => $data['position_y'],
-                    'rotation' => $data['rotation'] ?? 0,
-                    'order' => $index,
-                ];
-            });
+            if ($request->has('markerBlocks')) {
+                $this->reconcileBlocks($room, $room->markerBlocks(), $request->markerBlocks, function ($data, $index) {
+                    return [
+                        'name' => $data['name'],
+                        'type' => $data['type'],
+                        'position_x' => $data['position_x'],
+                        'position_y' => $data['position_y'],
+                        'rotation' => $data['rotation'] ?? 0,
+                        'order' => $index,
+                    ];
+                });
+            }
 
             $nextBlockOrder = ($room->blocks()->max('order') ?? -1) + 1;
 
@@ -249,7 +262,12 @@ class RoomLayoutController extends Controller
      */
     private function reconcileBlocks(Room $room, $scope, array $submitted, callable $attributes): void
     {
-        $submittedIds = collect($submitted)->pluck('id')->filter()->all();
+        $isTempId = fn ($id) => is_string($id) && str_starts_with($id, 'temp-');
+
+        $submittedIds = collect($submitted)
+            ->pluck('id')
+            ->filter(fn ($id) => $id !== null && ! $isTempId($id))
+            ->all();
         $toDelete = array_diff($scope->clone()->pluck('id')->all(), $submittedIds);
 
         if (! empty($toDelete)) {
@@ -258,9 +276,10 @@ class RoomLayoutController extends Controller
 
         foreach ($submitted as $index => $data) {
             $values = $attributes($data, $index);
+            $id = $data['id'] ?? null;
 
-            if ($data['id']) {
-                $scope->clone()->where('id', $data['id'])->update($values);
+            if ($id !== null && ! $isTempId($id)) {
+                $scope->clone()->where('id', $id)->update($values);
             } else {
                 $room->allBlocks()->create($values);
             }

--- a/app/Http/Controllers/Admin/RoomLayoutController.php
+++ b/app/Http/Controllers/Admin/RoomLayoutController.php
@@ -32,6 +32,8 @@ class RoomLayoutController extends Controller
         // Load stage blocks
         $stageBlocks = $room->stageBlocks()->get();
 
+        $markerBlocks = $room->markerBlocks()->get();
+
         // If no stage blocks exist but old stage_x/stage_y exist, migrate them
         if ($stageBlocks->isEmpty() && ($room->stage_x !== null || $room->stage_y !== null)) {
             $stageBlocks = collect([
@@ -61,6 +63,7 @@ class RoomLayoutController extends Controller
             'bookingsCount' => $bookingsCount,
             'blocks' => $blocks,
             'stageBlocks' => $stageBlocks,
+            'markerBlocks' => $markerBlocks,
             'blockIdMap' => session('blockIdMap', []),
             'title' => 'Floor Plan Editor',
             'breadcrumbs' => [
@@ -81,6 +84,13 @@ class RoomLayoutController extends Controller
             'stageBlocks.*.name' => 'required|string|max:255',
             'stageBlocks.*.position_x' => 'required|integer|min:-1',
             'stageBlocks.*.position_y' => 'required|integer|min:-1',
+            'markerBlocks' => 'sometimes|array',
+            'markerBlocks.*.id' => ['nullable', Rule::in($room->markerBlocks()->pluck('id')->all())],
+            'markerBlocks.*.type' => 'required|string|in:entrance,comment',
+            'markerBlocks.*.name' => 'required|string|max:255',
+            'markerBlocks.*.position_x' => 'required|integer|min:-1',
+            'markerBlocks.*.position_y' => 'required|integer|min:-1',
+            'markerBlocks.*.rotation' => 'nullable|integer|in:0,90,180,270',
             'blocks' => 'required|array',
             'blocks.*.id' => [
                 'required',
@@ -138,6 +148,33 @@ class RoomLayoutController extends Controller
                         'rotation' => 0,
                         'order' => $index,
                     ]);
+                }
+            }
+
+            // Update marker blocks
+            $existingMarkerBlockIds = $room->markerBlocks()->pluck('id')->toArray();
+            $submittedMarkerBlocks = $request->markerBlocks ?? [];
+            $submittedMarkerBlockIds = collect($submittedMarkerBlocks)->pluck('id')->filter()->toArray();
+
+            $markerBlocksToDelete = array_diff($existingMarkerBlockIds, $submittedMarkerBlockIds);
+            if (! empty($markerBlocksToDelete)) {
+                $room->markerBlocks()->whereIn('id', $markerBlocksToDelete)->delete();
+            }
+
+            foreach ($submittedMarkerBlocks as $index => $markerBlockData) {
+                $attributes = [
+                    'name' => $markerBlockData['name'],
+                    'type' => $markerBlockData['type'],
+                    'position_x' => $markerBlockData['position_x'],
+                    'position_y' => $markerBlockData['position_y'],
+                    'rotation' => $markerBlockData['rotation'] ?? 0,
+                    'order' => $index,
+                ];
+
+                if ($markerBlockData['id']) {
+                    $room->markerBlocks()->where('id', $markerBlockData['id'])->update($attributes);
+                } else {
+                    $room->allBlocks()->create($attributes);
                 }
             }
 

--- a/app/Http/Controllers/Admin/RoomLayoutController.php
+++ b/app/Http/Controllers/Admin/RoomLayoutController.php
@@ -88,24 +88,24 @@ class RoomLayoutController extends Controller
             'stageBlocks' => 'sometimes|array',
             'stageBlocks.*.id' => ['nullable', $ownedId($room->stageBlocks(), 'The selected stage block id is invalid for this room.')],
             'stageBlocks.*.name' => 'required|string|max:255',
-            'stageBlocks.*.position_x' => 'required|integer|min:-1',
-            'stageBlocks.*.position_y' => 'required|integer|min:-1',
+            'stageBlocks.*.position_x' => 'required|integer|min:-1|max:11',
+            'stageBlocks.*.position_y' => 'required|integer|min:-1|max:7',
             'markerBlocks' => 'sometimes|array',
             'markerBlocks.*.id' => ['nullable', $ownedId($room->markerBlocks(), 'The selected marker block id is invalid for this room.')],
             'markerBlocks.*.type' => 'required|string|in:entrance,comment',
             'markerBlocks.*.name' => 'required|string|max:255',
-            'markerBlocks.*.position_x' => ['required', 'integer', 'min:-1', 'max:11'],
-            'markerBlocks.*.position_y' => ['required', 'integer', 'min:-1', 'max:7'],
+            'markerBlocks.*.position_x' => 'required|integer|min:-1|max:11',
+            'markerBlocks.*.position_y' => 'required|integer|min:-1|max:7',
             'markerBlocks.*.rotation' => 'nullable|integer|in:0,90,180,270',
             'markerBlocks.*' => [
-                function (string $attribute, $value, $fail) {
+                function (string $_attribute, $value, $fail) {
                     $type = $value['type'] ?? null;
                     $x = isset($value['position_x']) ? (int) $value['position_x'] : null;
                     $y = isset($value['position_y']) ? (int) $value['position_y'] : null;
                     if ($type === 'comment' && ($x === -1 || $y === -1)) {
                         $fail('Comment markers must have valid grid coordinates.');
                     }
-                    if ($type === 'entrance' && $x === -1 && $y === -1) {
+                    if ($type === 'entrance' && ($x === -1) === ($y === -1)) {
                         $fail('Entrance markers must be placed on a row or column.');
                     }
                 },
@@ -113,8 +113,8 @@ class RoomLayoutController extends Controller
             'blocks' => 'required|array',
             'blocks.*.id' => ['required', $ownedId($room->blocks(), 'The selected block id is invalid for this room.')],
             'blocks.*.name' => 'required|string|max:255',
-            'blocks.*.position_x' => 'required|integer|min:-1',
-            'blocks.*.position_y' => 'required|integer|min:-1',
+            'blocks.*.position_x' => 'required|integer|min:-1|max:11',
+            'blocks.*.position_y' => 'required|integer|min:-1|max:7',
             'blocks.*.rotation' => 'required|integer|in:0,90,180,270',
             'blocks.*.rowsData' => 'nullable|array',
             'blocks.*.rowsData.*.rowNumber' => 'integer|min:1|max:50',

--- a/app/Http/Controllers/Admin/RoomLayoutController.php
+++ b/app/Http/Controllers/Admin/RoomLayoutController.php
@@ -136,7 +136,7 @@ class RoomLayoutController extends Controller
                         'rotation' => 0,
                         'order' => $index,
                     ];
-                });
+                }, $blockIdMap);
             }
 
             if ($request->has('markerBlocks')) {
@@ -149,7 +149,7 @@ class RoomLayoutController extends Controller
                         'rotation' => $data['rotation'] ?? 0,
                         'order' => $index,
                     ];
-                });
+                }, $blockIdMap);
             }
 
             $nextBlockOrder = ($room->blocks()->max('order') ?? -1) + 1;
@@ -260,7 +260,7 @@ class RoomLayoutController extends Controller
      * @param  \Illuminate\Database\Eloquent\Relations\HasMany  $scope
      * @param  array<int,array<string,mixed>>  $submitted
      */
-    private function reconcileBlocks(Room $room, $scope, array $submitted, callable $attributes): void
+    private function reconcileBlocks(Room $room, $scope, array $submitted, callable $attributes, array &$blockIdMap = []): void
     {
         $isTempId = fn ($id) => is_string($id) && str_starts_with($id, 'temp-');
 
@@ -281,7 +281,10 @@ class RoomLayoutController extends Controller
             if ($id !== null && ! $isTempId($id)) {
                 $scope->clone()->where('id', $id)->update($values);
             } else {
-                $room->allBlocks()->create($values);
+                $block = $room->allBlocks()->create($values);
+                if ($id !== null) {
+                    $blockIdMap[$id] = $block->id;
+                }
             }
         }
     }

--- a/app/Http/Controllers/BookingController.php
+++ b/app/Http/Controllers/BookingController.php
@@ -103,6 +103,10 @@ class BookingController extends Controller
             ->orderBy('order')
             ->get();
 
+        $markerBlocks = $event->room->markerBlocks()
+            ->select('id', 'room_id', 'name', 'type', 'position_x', 'position_y', 'rotation', 'order')
+            ->get();
+
         return Inertia::render('Booking/CreateBooking', [
             'event' => array_merge($event->only(['id', 'name', 'starts_at', 'reservation_ends_at', 'booking_starts_at']), [
                 'tickets_left' => $ticketsLeft,
@@ -111,6 +115,7 @@ class BookingController extends Controller
             'room' => $event->room->only(['id', 'name', 'stage_x', 'stage_y']),
             'blocks' => $blocks,
             'stageBlocks' => $stageBlocks,
+            'markerBlocks' => $markerBlocks,
             'bookedSeats' => $bookedSeats,
             'selectedSeats' => $request->get('seats', []), // Pass selected seats from URL
             'maxSeatsPerUser' => min(self::MAX_SEATS_PER_EVENT, $ticketsLeft),
@@ -297,6 +302,10 @@ class BookingController extends Controller
             ->orderBy('order')
             ->get();
 
+        $markerBlocks = $event->room->markerBlocks()
+            ->select('id', 'room_id', 'name', 'type', 'position_x', 'position_y', 'rotation', 'order')
+            ->get();
+
         // Get user's booked seat IDs for highlighting
         $userBookedSeats = Booking::where('event_id', $event->id)
             ->where('user_id', auth()->id())
@@ -313,6 +322,7 @@ class BookingController extends Controller
             'event' => $event,
             'booking' => $booking,
             'blocks' => $blocks,
+            'markerBlocks' => $markerBlocks,
             'bookedSeats' => $bookedSeats,
             'userBookedSeats' => $userBookedSeats,
         ]);

--- a/app/Models/Block.php
+++ b/app/Models/Block.php
@@ -50,4 +50,10 @@ class Block extends Model
     {
         return $query->where('type', 'stage');
     }
+
+    // Non-bookable annotation blocks: entrance rows/columns and text comments.
+    public function scopeMarker($query)
+    {
+        return $query->whereIn('type', ['entrance', 'comment']);
+    }
 }

--- a/app/Models/Room.php
+++ b/app/Models/Room.php
@@ -32,6 +32,11 @@ class Room extends Model
         return $this->hasMany(Block::class)->stage()->orderBy('order');
     }
 
+    public function markerBlocks(): HasMany
+    {
+        return $this->hasMany(Block::class)->marker()->orderBy('order');
+    }
+
     public function allBlocks(): HasMany
     {
         return $this->hasMany(Block::class)->orderBy('order');

--- a/app/Services/Svg/MasterCardSvgGenerator.php
+++ b/app/Services/Svg/MasterCardSvgGenerator.php
@@ -249,14 +249,16 @@ class MasterCardSvgGenerator
         $cx = $x + $w / 2;
         $cy = $y + $h / 2;
 
+        $availableLength = $orientation === 'row' ? $w : $h;
         $labelW = $this->svg->textWidth($mpdf, $label, $sz);
-        $labelSvg = $this->svg->centeredLabelX($mpdf, $label, $sz, '#000000', $cx, $cy + $sz * SvgUtilities::BASELINE_FACTOR, $orientation === 'row' ? $w : $h);
+        $effectiveLabelW = min($labelW, $availableLength);
+        $labelSvg = $this->svg->centeredLabelX($mpdf, $label, $sz, '#000000', $cx, $cy + $sz * SvgUtilities::BASELINE_FACTOR, $availableLength);
         $textAngle = $rotation === 270 ? -90 : 90;
         $svg .= $orientation === 'row'
             ? $labelSvg
             : sprintf('<g transform="rotate(%d %.1f %.1f)">%s</g>', $textAngle, $cx, $cy, $labelSvg);
 
-        $arrowGap = $labelW / 2 + self::ARROW_LABEL_GAP;
+        $arrowGap = $effectiveLabelW / 2 + self::ARROW_LABEL_GAP;
         [$before, $after] = $orientation === 'row'
             ? [[$cx - $arrowGap, $cy], [$cx + $arrowGap, $cy]]
             : [[$cx, $cy - $arrowGap], [$cx, $cy + $arrowGap]];

--- a/app/Services/Svg/MasterCardSvgGenerator.php
+++ b/app/Services/Svg/MasterCardSvgGenerator.php
@@ -19,6 +19,10 @@ class MasterCardSvgGenerator
 
     private const STAGE_SIZE = 90;
 
+    private const ENTRANCE_BAND = 44; // thickness of an entrance band
+
+    private const ARROW_LABEL_GAP = 22; // gap between an entrance label and its arrows
+
     public function __construct(private SvgUtilities $svg) {}
 
     /**
@@ -26,32 +30,54 @@ class MasterCardSvgGenerator
      *
      * @param  Collection  $blocks  Seating blocks with rows.seats.
      * @param  Collection  $stageBlocks  Stage blocks.
+     * @param  Collection  $markerBlocks  Entrance and comment marker blocks.
      * @param  array<int,bool>  $bookedSeatIds  Set of booked seat IDs.
      */
-    public function render(Collection $blocks, Collection $stageBlocks, array $bookedSeatIds, Mpdf $mpdf): string
+    public function render(Collection $blocks, Collection $stageBlocks, Collection $markerBlocks, array $bookedSeatIds, Mpdf $mpdf): string
     {
-        $cells = $this->cells($blocks, $stageBlocks);
+        $cells = $this->cells($blocks, $stageBlocks, $markerBlocks);
         if (empty($cells)) {
             return '';
         }
 
         [$colW, $rowH] = $this->gridSizes($cells);
+
+        $occupied = $this->occupiedRange($cells);
+
+        // Reserve a grid line for each entrance so its row/column gets a slot even when
+        // no other block shares that line.
+        foreach ($markerBlocks as $mb) {
+            if ($mb->type !== 'entrance') {
+                continue;
+            }
+            if ((int) $mb->position_x === -1 && $mb->position_y >= 0) {
+                $rowH[$mb->position_y] = max($rowH[$mb->position_y] ?? 0, self::ENTRANCE_BAND);
+            }
+            if ((int) $mb->position_y === -1 && $mb->position_x >= 0) {
+                $colW[$mb->position_x] = max($colW[$mb->position_x] ?? 0, self::ENTRANCE_BAND);
+            }
+        }
+
         [$colX, $width] = $this->gridLinePositions($colW);
         [$rowY, $height] = $this->gridLinePositions($rowH);
 
+        $entranceSvg = $this->entranceMarkers($markerBlocks, $occupied, $colX, $rowY, $colW, $rowH, $mpdf);
+
         $svg = '';
         foreach ($cells as $c) {
-            $cw = $c['type'] === 'stage' ? $colW[$c['x']] : $c['w'];
+            $cw = in_array($c['type'], ['stage', 'comment'], true) ? $colW[$c['x']] : $c['w'];
             $bx = $colX[$c['x']] + ($colW[$c['x']] - $cw) / 2;
             $by = $rowY[$c['y']];
-            $svg .= $c['type'] === 'stage'
-                ? $this->stageCell($c, $bx, $by, $cw, $rowH[$c['y']], $mpdf)
-                : $this->seatingCell($c, $bx, $by, $bookedSeatIds, $mpdf);
+            $svg .= match ($c['type']) {
+                'stage' => $this->stageCell($c, $bx, $by, $cw, $rowH[$c['y']], $mpdf),
+                'comment' => $this->commentCell($c, $bx, $by, $cw, $rowH[$c['y']], $mpdf),
+                default => $this->seatingCell($c, $bx, $by, $bookedSeatIds, $mpdf),
+            };
         }
 
         $scale = min(200 / $width, 110 / $height);
 
-        return $this->svg->document($width, $height, $width * $scale, $height * $scale, $svg);
+        return $this->svg->document($width, $height, $width * $scale, $height * $scale, $svg.$entranceSvg);
     }
 
     /**
@@ -59,7 +85,7 @@ class MasterCardSvgGenerator
      *
      * @return array<int,array<string,mixed>>
      */
-    private function cells(Collection $blocks, Collection $stageBlocks): array
+    private function cells(Collection $blocks, Collection $stageBlocks, Collection $markerBlocks): array
     {
         $placed = fn ($b) => $b->position_x !== null && $b->position_y !== null && $b->position_x >= 0 && $b->position_y >= 0;
 
@@ -67,6 +93,11 @@ class MasterCardSvgGenerator
         foreach ($stageBlocks as $sb) {
             if ($placed($sb)) {
                 $cells[] = ['x' => $sb->position_x, 'y' => $sb->position_y, 'type' => 'stage', 'block' => $sb, 'w' => self::STAGE_SIZE, 'h' => self::STAGE_SIZE];
+            }
+        }
+        foreach ($markerBlocks as $mb) {
+            if ($mb->type === 'comment' && $placed($mb)) {
+                $cells[] = ['x' => $mb->position_x, 'y' => $mb->position_y, 'type' => 'comment', 'block' => $mb, 'w' => self::STAGE_SIZE, 'h' => self::STAGE_SIZE];
             }
         }
         foreach ($blocks as $b) {
@@ -109,6 +140,23 @@ class MasterCardSvgGenerator
     }
 
     /**
+     * Min/max column and row occupied by real cells (seating, stage, comment).
+     *
+     * @param  array<int,array<string,mixed>>  $cells
+     * @return array{minX:int, maxX:int, minY:int, maxY:int}
+     */
+    private function occupiedRange(array $cells): array
+    {
+        $xs = array_column($cells, 'x');
+        $ys = array_column($cells, 'y');
+
+        return [
+            'minX' => min($xs), 'maxX' => max($xs),
+            'minY' => min($ys), 'maxY' => max($ys),
+        ];
+    }
+
+    /**
      * @param  array<int,float>  $sizes  Cell size per grid index
      * @return array{0: array<int,float>, 1: float} [start pixel per index, total length]
      */
@@ -130,6 +178,93 @@ class MasterCardSvgGenerator
 
         return $this->svg->rect($bx, $by, $cw, $ch, '#000000', 2, 10)
             .$this->svg->centeredLabelX($mpdf, $c['block']->name ?: 'Stage', $sz, '#ffffff', $bx + $cw / 2, $by + $ch / 2 + $sz * SvgUtilities::BASELINE_FACTOR, $cw - 12);
+    }
+
+    private function commentCell(array $c, float $bx, float $by, float $cw, float $ch, Mpdf $mpdf): string
+    {
+        $sz = SvgUtilities::SIZE_STAGE_LABEL;
+
+        return $this->svg->rect($bx, $by, $cw, $ch, 'none', 2, 10)
+            .$this->svg->centeredLabelX($mpdf, $c['block']->name, $sz, '#000000', $bx + $cw / 2, $by + $ch / 2 + $sz * SvgUtilities::BASELINE_FACTOR, $cw - 12);
+    }
+
+    /**
+     * @param  array{minX:int, maxX:int, minY:int, maxY:int}  $occupied
+     * @param  array<int,float>  $colX
+     * @param  array<int,float>  $rowY
+     * @param  array<int,float>  $colW
+     * @param  array<int,float>  $rowH
+     */
+    private function entranceMarkers(Collection $markerBlocks, array $occupied, array $colX, array $rowY, array $colW, array $rowH, Mpdf $mpdf): string
+    {
+        if (empty($colX) || empty($rowY)) {
+            return '';
+        }
+
+        $spanLeft = $colX[$occupied['minX']];
+        $spanRight = $colX[$occupied['maxX']] + $colW[$occupied['maxX']];
+        $spanTop = $rowY[$occupied['minY']];
+        $spanBottom = $rowY[$occupied['maxY']] + $rowH[$occupied['maxY']];
+
+        $band = self::ENTRANCE_BAND;
+        $svg = '';
+
+        foreach ($markerBlocks as $mb) {
+            if ($mb->type !== 'entrance') {
+                continue;
+            }
+            $rotation = (int) ($mb->rotation ?? 0);
+
+            if ((int) $mb->position_x === -1 && isset($rowY[$mb->position_y])) {
+                $y = $rowY[$mb->position_y] + ($rowH[$mb->position_y] - $band) / 2;
+                $svg .= $this->entranceBand($spanLeft, $y, $spanRight - $spanLeft, $band, 'row', $rotation, $mb->name, $mpdf);
+            }
+
+            if ((int) $mb->position_y === -1 && isset($colX[$mb->position_x])) {
+                $x = $colX[$mb->position_x] + ($colW[$mb->position_x] - $band) / 2;
+                $svg .= $this->entranceBand($x, $spanTop, $band, $spanBottom - $spanTop, 'column', $rotation, $mb->name, $mpdf);
+            }
+        }
+
+        return $svg;
+    }
+
+    private function arrowDirection(int $rotation): string
+    {
+        return match ($rotation) {
+            90 => 'right',
+            180 => 'down',
+            270 => 'left',
+            default => 'up',
+        };
+    }
+
+    private function entranceBand(float $x, float $y, float $w, float $h, string $orientation, int $rotation, string $name, Mpdf $mpdf): string
+    {
+        $svg = $this->svg->rect($x, $y, $w, $h, '#ffffff', 2, 8, '6 4');
+
+        $sz = SvgUtilities::SIZE_BLOCK_LABEL;
+        $dir = $this->arrowDirection($rotation);
+        $label = $name ?: 'Entrance';
+        $cx = $x + $w / 2;
+        $cy = $y + $h / 2;
+
+        $labelW = $this->svg->textWidth($mpdf, $label, $sz);
+        $labelSvg = $this->svg->centeredLabelX($mpdf, $label, $sz, '#000000', $cx, $cy + $sz * SvgUtilities::BASELINE_FACTOR, $orientation === 'row' ? $w : $h);
+        $textAngle = $rotation === 270 ? -90 : 90;
+        $svg .= $orientation === 'row'
+            ? $labelSvg
+            : sprintf('<g transform="rotate(%d %.1f %.1f)">%s</g>', $textAngle, $cx, $cy, $labelSvg);
+
+        $arrowGap = $labelW / 2 + self::ARROW_LABEL_GAP;
+        [$before, $after] = $orientation === 'row'
+            ? [[$cx - $arrowGap, $cy], [$cx + $arrowGap, $cy]]
+            : [[$cx, $cy - $arrowGap], [$cx, $cy + $arrowGap]];
+
+        $svg .= $this->svg->centeredArrowHead($before[0], $before[1], $dir);
+        $svg .= $this->svg->centeredArrowHead($after[0], $after[1], $dir);
+
+        return $svg;
     }
 
     private function seatingCell(array $c, float $bx, float $by, array $bookedSeatIds, Mpdf $mpdf): string

--- a/app/Services/Svg/MasterCardSvgGenerator.php
+++ b/app/Services/Svg/MasterCardSvgGenerator.php
@@ -63,14 +63,17 @@ class MasterCardSvgGenerator
 
         $entranceSvg = $this->entranceMarkers($markerBlocks, $occupied, $colX, $rowY, $colW, $rowH, $mpdf);
 
+        $spanPx = fn (int $start, int $span, array $starts, array $sizes): float => $starts[$start + $span - 1] + $sizes[$start + $span - 1] - $starts[$start];
+
         $svg = '';
         foreach ($cells as $c) {
-            $cw = in_array($c['type'], ['stage', 'comment'], true) ? $colW[$c['x']] : $c['w'];
-            $bx = $colX[$c['x']] + ($colW[$c['x']] - $cw) / 2;
+            $bx = $colX[$c['x']];
             $by = $rowY[$c['y']];
+            $cw = $spanPx($c['x'], $c['colSpan'], $colX, $colW);
+            $ch = $spanPx($c['y'], $c['rowSpan'], $rowY, $rowH);
             $svg .= match ($c['type']) {
-                'stage' => $this->stageCell($c, $bx, $by, $cw, $rowH[$c['y']], $mpdf),
-                'comment' => $this->commentCell($c, $bx, $by, $cw, $rowH[$c['y']], $mpdf),
+                'stage' => $this->stageCell($c, $bx, $by, $cw, $ch, $mpdf),
+                'comment' => $this->commentCell($c, $bx, $by, $cw, $ch, $mpdf),
                 default => $this->seatingCell($c, $bx, $by, $bookedSeatIds, $mpdf),
             };
         }
@@ -92,12 +95,12 @@ class MasterCardSvgGenerator
         $cells = [];
         foreach ($stageBlocks as $sb) {
             if ($placed($sb)) {
-                $cells[] = ['x' => $sb->position_x, 'y' => $sb->position_y, 'type' => 'stage', 'block' => $sb, 'w' => self::STAGE_SIZE, 'h' => self::STAGE_SIZE];
+                $cells[] = ['x' => $sb->position_x, 'y' => $sb->position_y, 'type' => 'stage', 'block' => $sb, 'w' => self::STAGE_SIZE, 'h' => self::STAGE_SIZE, 'colSpan' => 1, 'rowSpan' => 1];
             }
         }
         foreach ($markerBlocks as $mb) {
             if ($mb->type === 'comment' && $placed($mb)) {
-                $cells[] = ['x' => $mb->position_x, 'y' => $mb->position_y, 'type' => 'comment', 'block' => $mb, 'w' => self::STAGE_SIZE, 'h' => self::STAGE_SIZE];
+                $cells[] = ['x' => $mb->position_x, 'y' => $mb->position_y, 'type' => 'comment', 'block' => $mb, 'w' => self::STAGE_SIZE, 'h' => self::STAGE_SIZE, 'colSpan' => 1, 'rowSpan' => 1];
             }
         }
         foreach ($blocks as $b) {
@@ -118,10 +121,64 @@ class MasterCardSvgGenerator
                 'gridCols' => $gridCols, 'gridRows' => $gridRows,
                 'w' => self::IN_PAD * 2 + $gridCols * self::PITCH,
                 'h' => self::HEADER + self::IN_PAD + $gridRows * self::PITCH,
+                'colSpan' => 1, 'rowSpan' => 1,
             ];
         }
 
+        $this->mergeAdjacentCells($cells, 'stage');
+        $this->mergeAdjacentCells($cells, 'comment');
+
         return $cells;
+    }
+
+    /**
+     * @param  array<int,array<string,mixed>>  $cells
+     */
+    private function mergeAdjacentCells(array &$cells, string $type): void
+    {
+        $grid = [];
+        foreach ($cells as $i => $c) {
+            if ($c['type'] === $type) {
+                $grid[$c['y']][$c['x']] = $i;
+            }
+        }
+        ksort($grid);
+
+        $covered = [];
+        $match = fn (int $y, int $x, string $name) => isset($grid[$y][$x]) && ! isset($covered[$grid[$y][$x]]) && $cells[$grid[$y][$x]]['block']->name === $name;
+
+        foreach ($grid as $y => $row) {
+            ksort($row);
+            foreach ($row as $x => $i) {
+                if (isset($covered[$i])) {
+                    continue;
+                }
+
+                $name = $cells[$i]['block']->name;
+                $colSpan = 1;
+                while ($match($y, $x + $colSpan, $name)) {
+                    $colSpan++;
+                }
+
+                $rowSpan = 1;
+                while (! in_array(false, array_map(fn ($dc) => $match($y + $rowSpan, $x + $dc, $name), range(0, $colSpan - 1)))) {
+                    $rowSpan++;
+                }
+
+                $cells[$i]['colSpan'] = $colSpan;
+                $cells[$i]['rowSpan'] = $rowSpan;
+
+                for ($dr = 0; $dr < $rowSpan; $dr++) {
+                    for ($dc = 0; $dc < $colSpan; $dc++) {
+                        if ($dr || $dc) {
+                            $covered[$grid[$y + $dr][$x + $dc]] = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        $cells = array_values(array_filter($cells, fn ($i) => ! isset($covered[$i]), ARRAY_FILTER_USE_KEY));
     }
 
     /**
@@ -132,8 +189,12 @@ class MasterCardSvgGenerator
     {
         $colW = $rowH = [];
         foreach ($cells as $c) {
-            $colW[$c['x']] = max($colW[$c['x']] ?? 0, $c['w']);
-            $rowH[$c['y']] = max($rowH[$c['y']] ?? 0, $c['h']);
+            for ($dx = 0; $dx < $c['colSpan']; $dx++) {
+                $colW[$c['x'] + $dx] = max($colW[$c['x'] + $dx] ?? 0, $c['w'] / $c['colSpan']);
+            }
+            for ($dy = 0; $dy < $c['rowSpan']; $dy++) {
+                $rowH[$c['y'] + $dy] = max($rowH[$c['y'] + $dy] ?? 0, $c['h'] / $c['rowSpan']);
+            }
         }
 
         return [$colW, $rowH];
@@ -147,13 +208,16 @@ class MasterCardSvgGenerator
      */
     private function occupiedRange(array $cells): array
     {
-        $xs = array_column($cells, 'x');
-        $ys = array_column($cells, 'y');
+        $minX = $minY = PHP_INT_MAX;
+        $maxX = $maxY = PHP_INT_MIN;
+        foreach ($cells as $c) {
+            $minX = min($minX, $c['x']);
+            $minY = min($minY, $c['y']);
+            $maxX = max($maxX, $c['x'] + $c['colSpan'] - 1);
+            $maxY = max($maxY, $c['y'] + $c['rowSpan'] - 1);
+        }
 
-        return [
-            'minX' => min($xs), 'maxX' => max($xs),
-            'minY' => min($ys), 'maxY' => max($ys),
-        ];
+        return ['minX' => $minX, 'maxX' => $maxX, 'minY' => $minY, 'maxY' => $maxY];
     }
 
     /**

--- a/app/Services/Svg/SvgUtilities.php
+++ b/app/Services/Svg/SvgUtilities.php
@@ -20,6 +20,8 @@ class SvgUtilities
 
     public const BASELINE_FACTOR = 0.35;
 
+    public const ARROW_TIP_REACH = 14;
+
     private const STROKE = '#000000';
 
     public function centeredLabelX(Mpdf $mpdf, string $text, float $preferredSize, string $color, float $centerX, float $baselineY, float $maxWidth): string
@@ -58,13 +60,14 @@ class SvgUtilities
         );
     }
 
-    public function rect(float $x, float $y, float $w, float $h, string $fill, float $strokeWidth, float $rx = 0): string
+    public function rect(float $x, float $y, float $w, float $h, string $fill, float $strokeWidth, float $rx = 0, ?string $dashArray = null): string
     {
         $corners = $rx > 0 ? sprintf(' rx="%.1f" ry="%.1f"', $rx, $rx) : '';
+        $dash = $dashArray !== null ? sprintf(' stroke-dasharray="%s"', $dashArray) : '';
 
         return sprintf(
-            '<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f"%s fill="%s" stroke="%s" stroke-width="%.1f"/>',
-            $x, $y, $w, $h, $corners, $fill, self::STROKE, $strokeWidth
+            '<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f"%s fill="%s" stroke="%s" stroke-width="%.1f"%s/>',
+            $x, $y, $w, $h, $corners, $fill, self::STROKE, $strokeWidth, $dash
         );
     }
 
@@ -83,17 +86,31 @@ class SvgUtilities
 
     public function arrowHead(float $x, float $y, string $direction): string
     {
-        $s = 14;
+        $s = self::ARROW_TIP_REACH;
+        $base = $s * 0.6;
         [$tip, $a, $b] = match ($direction) {
-            'right' => [[$x + $s, $y], [$x - $s * 0.6, $y - $s], [$x - $s * 0.6, $y + $s]],
-            'left' => [[$x - $s, $y], [$x + $s * 0.6, $y - $s], [$x + $s * 0.6, $y + $s]],
-            'down' => [[$x, $y + $s], [$x - $s, $y - $s * 0.6], [$x + $s, $y - $s * 0.6]],
-            'up' => [[$x, $y - $s], [$x - $s, $y + $s * 0.6], [$x + $s, $y + $s * 0.6]],
+            'right' => [[$x + $s, $y], [$x - $base, $y - $s], [$x - $base, $y + $s]],
+            'left' => [[$x - $s, $y], [$x + $base, $y - $s], [$x + $base, $y + $s]],
+            'down' => [[$x, $y + $s], [$x - $s, $y - $base], [$x + $s, $y - $base]],
+            'up' => [[$x, $y - $s], [$x - $s, $y + $base], [$x + $s, $y + $base]],
         };
 
         return sprintf(
             '<polygon points="%.1f,%.1f %.1f,%.1f %.1f,%.1f" fill="#000000" stroke="#ffffff" stroke-width="1.5"/>',
             $tip[0], $tip[1], $a[0], $a[1], $b[0], $b[1]
         );
+    }
+
+    public function centeredArrowHead(float $x, float $y, string $direction): string
+    {
+        $tipOverhang = (self::ARROW_TIP_REACH - self::ARROW_TIP_REACH * 0.6) / 2;
+        $x += match ($direction) {
+            'right' => -$tipOverhang, 'left' => $tipOverhang, default => 0
+        };
+        $y += match ($direction) {
+            'down' => -$tipOverhang, 'up' => $tipOverhang, default => 0
+        };
+
+        return $this->arrowHead($x, $y, $direction);
     }
 }

--- a/database/factories/BlockFactory.php
+++ b/database/factories/BlockFactory.php
@@ -21,8 +21,8 @@ class BlockFactory extends Factory
             'room_id' => Room::factory(),
             'name' => fake()->randomElement(['Block A', 'Block B', 'Block C', 'Main Floor', 'Balcony']),
             'type' => 'seating',
-            'position_x' => fake()->numberBetween(0, 10),
-            'position_y' => fake()->numberBetween(0, 10),
+            'position_x' => fake()->numberBetween(0, 11),
+            'position_y' => fake()->numberBetween(0, 7),
             'rotation' => fake()->randomElement([0, 90, 180, 270]),
             'order' => fake()->numberBetween(0, 10),
         ];

--- a/database/factories/BlockFactory.php
+++ b/database/factories/BlockFactory.php
@@ -47,7 +47,26 @@ class BlockFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'type' => 'stage',
             'name' => fake()->randomElement(['Main Stage', 'Side Stage', 'Platform', 'Podium']),
-            'rotation' => 0, // Stages typically don't rotate
+            'rotation' => 0,
+        ]);
+    }
+
+    public function entrance(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'type' => 'entrance',
+            'name' => 'Entrance',
+            'position_x' => -1,
+            'position_y' => 2,
+            'rotation' => 0,
+        ]);
+    }
+
+    public function comment(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'type' => 'comment',
+            'name' => 'Note',
         ]);
     }
 }

--- a/resources/js/Components/SeatBlock.vue
+++ b/resources/js/Components/SeatBlock.vue
@@ -44,7 +44,7 @@ const getRowOrder = (rows: Row[], rotation: number) => {
   return rows
 }
 
-const getJustificationClass = (alignment: Alignment | undefined, rotation: number | undefined) => {
+const getJustificationClass = (alignment: Alignment | undefined, _rotation: number | undefined) => {
   switch (alignment ?? 'center') {
     case 'left': return 'justify-start'
     case 'right': return 'justify-end'

--- a/resources/js/Components/SeatBlock.vue
+++ b/resources/js/Components/SeatBlock.vue
@@ -1,28 +1,9 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-
-interface Seat {
-  id: number
-  label: string
-  name: string
-}
-
-interface Row {
-  id: number
-  name: string
-  alignment?: 'left' | 'center' | 'right'
-  seats: Seat[]
-}
-
-interface Block {
-  id: number
-  name: string
-  rotation: number
-  rows: Row[]
-}
+import type { Seat, Row, LayoutBlock, Alignment } from '@/types/layout'
 
 interface Props {
-  block: Block
+  block: LayoutBlock
   bookedSeats: number[]
   selectedSeats: number[]
   adminMode?: boolean
@@ -35,11 +16,8 @@ const emit = defineEmits<{
   'booked-seat-click': [seat: Seat]
 }>()
 
-// Get seat status styling
 const getSeatStatus = (seat: Seat) => {
-  const seatId = seat.id
-
-  if (props.bookedSeats.includes(seatId)) {
+  if (props.bookedSeats.includes(seat.id)) {
     return {
       classes: props.adminMode
         ? 'bg-red-500 border-red-600 text-white hover:bg-red-600 cursor-pointer'
@@ -47,78 +25,37 @@ const getSeatStatus = (seat: Seat) => {
       disabled: !props.adminMode
     }
   }
-
-  if (props.selectedSeats.includes(seatId)) {
-    return {
-      classes: 'bg-blue-500 border-blue-600 text-white scale-110',
-      disabled: false
-    }
+  if (props.selectedSeats.includes(seat.id)) {
+    return { classes: 'bg-blue-500 border-blue-600 text-white scale-110', disabled: false }
   }
-
-  return {
-    classes: 'bg-emerald-500 border-emerald-600 text-white hover:bg-emerald-600 hover:scale-110',
-    disabled: false
-  }
+  return { classes: 'bg-emerald-500 border-emerald-600 text-white hover:bg-emerald-600 hover:scale-110', disabled: false }
 }
 
-// Handle seat click
 const handleSeatClick = (seat: Seat) => {
-  const isBooked = props.bookedSeats.includes(seat.id)
-
-  if (isBooked) {
-    if (props.adminMode) {
-      emit('booked-seat-click', seat)
-    }
+  if (props.bookedSeats.includes(seat.id)) {
+    if (props.adminMode) emit('booked-seat-click', seat)
     return
   }
-
   emit('seat-click', seat)
 }
 
-// Get row order based on rotation
 const getRowOrder = (rows: Row[], rotation: number) => {
-  if (rotation === 180) {
-    return [...rows].reverse() // 180°: count down (10→1)
-  }
-  if (rotation === 270) {
-    return rows // 270°: normal order (1→10) - Row 1 on left, Row 10 on right
-  }
-  if (rotation === 90) {
-    return [...rows].reverse() // 90°: count down (10→1) - Row 1 on right, Row 10 on left
-  }
-  return rows // 0°: count up (1→10)
+  if (rotation === 90 || rotation === 180) return [...rows].reverse()
+  return rows
 }
 
-// Get justification class based on alignment and rotation
-const getJustificationClass = (alignment?: 'left' | 'center' | 'right', rotation?: number) => {
-  // Default to center if no alignment specified
-  const effectiveAlignment = alignment ?? 'center'
-  
-  if (rotation === 90 || rotation === 270) {
-    // For vertical orientations, reverse the mapping
-    switch (effectiveAlignment) {
-      case 'left': return 'justify-start'    // left becomes top (start)
-      case 'center': return 'justify-center' // center stays center
-      case 'right': return 'justify-end'     // right becomes bottom (end)
-      default: return 'justify-center'
-    }
-  } else {
-    // For horizontal orientations (0° and 180°)
-    switch (effectiveAlignment) {
-      case 'left': return 'justify-start'
-      case 'center': return 'justify-center'
-      case 'right': return 'justify-end'
-      default: return 'justify-center'
-    }
+const getJustificationClass = (alignment: Alignment | undefined, rotation: number | undefined) => {
+  switch (alignment ?? 'center') {
+    case 'left': return 'justify-start'
+    case 'right': return 'justify-end'
+    default: return 'justify-center'
   }
 }
 
-// Get layout classes based on rotation
 const getLayoutClasses = computed(() => {
   const rotation = props.block.rotation || 0
 
   if (rotation === 90) {
-    // 90° (→ arrow pointing right): separator on left, seats on right
     return {
       container: 'flex flex-row gap-1',
       rowSection: 'flex flex-row items-stretch',
@@ -128,7 +65,6 @@ const getLayoutClasses = computed(() => {
       seats: 'flex flex-col gap-1 items-center'
     }
   } else if (rotation === 270) {
-    // 270° (← arrow pointing left): seats on left, separator on right
     return {
       container: 'flex flex-row gap-1',
       rowSection: 'flex flex-row items-stretch',
@@ -138,7 +74,6 @@ const getLayoutClasses = computed(() => {
       seats: 'flex flex-col gap-1 items-start'
     }
   } else if (rotation === 180) {
-    // For 180°: reverse the row order (seats first, then separator)
     return {
       container: 'flex flex-col gap-1',
       rowSection: 'flex flex-col-reverse',
@@ -148,7 +83,6 @@ const getLayoutClasses = computed(() => {
       seats: 'flex flex-row gap-1 items-center flex-nowrap'
     }
   } else {
-    // For 0°: normal order (separator first, then seats)
     return {
       container: 'flex flex-col gap-1',
       rowSection: 'flex flex-col',
@@ -160,21 +94,12 @@ const getLayoutClasses = computed(() => {
   }
 })
 
-// Get block name position classes
 const getBlockNameClasses = computed(() => {
-  const rotation = props.block.rotation || 0
-
-  switch (rotation) {
-    case 0:
-      return 'absolute -top-5 left-1/2 transform -translate-x-1/2'
-    case 90:
-      return 'absolute top-1/2 -right-10 transform -translate-y-1/2 rotate-90'
-    case 180:
-      return 'absolute -bottom-5 left-1/2 transform -translate-x-1/2'
-    case 270:
-      return 'absolute top-1/2 -left-10 transform -translate-y-1/2 -rotate-90'
-    default:
-      return 'absolute -top-5 left-1/2 transform -translate-x-1/2'
+  switch (props.block.rotation || 0) {
+    case 90:  return 'absolute top-1/2 -right-10 transform -translate-y-1/2 rotate-90'
+    case 180: return 'absolute -bottom-5 left-1/2 transform -translate-x-1/2'
+    case 270: return 'absolute top-1/2 -left-10 transform -translate-y-1/2 -rotate-90'
+    default:  return 'absolute -top-5 left-1/2 transform -translate-x-1/2'
   }
 })
 
@@ -182,7 +107,6 @@ const getBlockNameClasses = computed(() => {
 
 <template>
   <div class="relative bg-white border border-gray-300 rounded-md p-3 shadow-sm w-fit h-fit max-w-none">
-    <!-- Block Name Label -->
     <div
       :class="[
         'z-10 bg-white px-1.5 py-0.5 rounded text-sm font-bold text-gray-800 shadow-sm border border-gray-200',
@@ -192,60 +116,41 @@ const getBlockNameClasses = computed(() => {
       {{ block.name }}
     </div>
 
-    <!-- Rows Container -->
     <div :class="getLayoutClasses.container">
       <div
-        v-for="row in getRowOrder(block.rows, block.rotation)"
+        v-for="row in getRowOrder(block.rows ?? [], block.rotation ?? 0)"
         :key="row.id"
         :class="[getLayoutClasses.rowSection, 'mb-0']"
       >
-        <!-- For 270°: separator first, then seats -->
         <template v-if="block.rotation === 270">
-          <!-- Row Separator -->
           <div :class="getLayoutClasses.separator">
             <span :class="getLayoutClasses.separatorLine"></span>
             <span :class="getLayoutClasses.separatorLabel">{{ row.name }}</span>
             <span :class="getLayoutClasses.separatorLine"></span>
           </div>
-
-          <!-- Seats Container -->
           <div :class="[getLayoutClasses.seats, getJustificationClass(row.alignment, block.rotation)]">
             <button
               v-for="seat in row.seats"
               :key="seat.id"
-              :class="[
-                'w-7 h-7 border rounded text-xs font-bold transition-all duration-200 flex items-center justify-center p-0 shrink-0',
-                getSeatStatus(seat).classes
-              ]"
+              :class="['w-7 h-7 border rounded text-xs font-bold transition-all duration-200 flex items-center justify-center p-0 shrink-0', getSeatStatus(seat).classes]"
               :disabled="getSeatStatus(seat).disabled"
               :title="`${block.name} - ${row.name} - ${seat.label || seat.name}`"
               @click="handleSeatClick(seat)"
-            >
-              {{ seat.label || seat.name }}
-            </button>
+            >{{ seat.label || seat.name }}</button>
           </div>
         </template>
 
-        <!-- For 90°: seats first, then separator (Seats | Row) -->
         <template v-else-if="block.rotation === 90">
-          <!-- Seats Container -->
           <div :class="[getLayoutClasses.seats, getJustificationClass(row.alignment, block.rotation)]">
             <button
               v-for="seat in row.seats"
               :key="seat.id"
-              :class="[
-                'w-7 h-7 border rounded text-xs font-bold transition-all duration-200 flex items-center justify-center p-0 shrink-0',
-                getSeatStatus(seat).classes
-              ]"
+              :class="['w-7 h-7 border rounded text-xs font-bold transition-all duration-200 flex items-center justify-center p-0 shrink-0', getSeatStatus(seat).classes]"
               :disabled="getSeatStatus(seat).disabled"
               :title="`${block.name} - ${row.name} - ${seat.label || seat.name}`"
               @click="handleSeatClick(seat)"
-            >
-              {{ seat.label || seat.name }}
-            </button>
+            >{{ seat.label || seat.name }}</button>
           </div>
-
-          <!-- Row Separator -->
           <div :class="getLayoutClasses.separator">
             <span :class="getLayoutClasses.separatorLine"></span>
             <span :class="getLayoutClasses.separatorLabel">{{ row.name }}</span>
@@ -253,30 +158,21 @@ const getBlockNameClasses = computed(() => {
           </div>
         </template>
 
-        <!-- For 0° and 180°: separator first, then seats (or reversed by flex-col-reverse) -->
         <template v-else>
-          <!-- Row Separator -->
           <div :class="getLayoutClasses.separator">
             <span :class="getLayoutClasses.separatorLine"></span>
             <span :class="getLayoutClasses.separatorLabel">{{ row.name }}</span>
             <span :class="getLayoutClasses.separatorLine"></span>
           </div>
-
-          <!-- Seats Container -->
           <div :class="[getLayoutClasses.seats, getJustificationClass(row.alignment, block.rotation)]">
             <button
               v-for="seat in row.seats"
               :key="seat.id"
-              :class="[
-                'w-7 h-7 border rounded text-xs font-bold transition-all duration-200 flex items-center justify-center p-0 shrink-0',
-                getSeatStatus(seat).classes
-              ]"
+              :class="['w-7 h-7 border rounded text-xs font-bold transition-all duration-200 flex items-center justify-center p-0 shrink-0', getSeatStatus(seat).classes]"
               :disabled="getSeatStatus(seat).disabled"
               :title="`${block.name} - ${row.name} - ${seat.label || seat.name}`"
               @click="handleSeatClick(seat)"
-            >
-              {{ seat.label || seat.name }}
-            </button>
+            >{{ seat.label || seat.name }}</button>
           </div>
         </template>
       </div>

--- a/resources/js/Components/SeatLayout.vue
+++ b/resources/js/Components/SeatLayout.vue
@@ -2,12 +2,19 @@
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import Panzoom from '@panzoom/panzoom'
 import SeatBlock from './SeatBlock.vue'
+import { ArrowUp, ArrowRight, ArrowDown, ArrowLeft } from 'lucide-vue-next'
+
+const arrow = (rotation) => ({ 0: ArrowUp, 90: ArrowRight, 180: ArrowDown, 270: ArrowLeft }[rotation] || ArrowUp)
 
 const props = defineProps({
   event: Object,
   room: Object,
   blocks: Array,
   stageBlocks: Array,
+  markerBlocks: {
+    type: Array,
+    default: () => []
+  },
   selectedSeats: Array,
   bookedSeats: Array,
   adminMode: {
@@ -18,93 +25,112 @@ const props = defineProps({
 
 const emit = defineEmits(['seats-changed', 'booked-seat-click'])
 
-// Seat selection state
 const selectedSeatIds = ref([...props.selectedSeats])
 
-// Panzoom refs
 const panzoomContainer = ref(null)
 const panzoomInstance = ref(null)
 
-// Calculate dynamic grid dimensions based on content
 const gridDimensions = computed(() => {
-  let maxX = 0
-  let maxY = 0
+  const b = blockBounds.value
+  let { minX, maxX, minY, maxY } = b
 
-  // Check stage blocks positions (0-based positioning)
-  props.stageBlocks?.forEach(stageBlock => {
-    if (stageBlock.position_x >= 0 && stageBlock.position_y >= 0) {
-      maxX = Math.max(maxX, stageBlock.position_x + 1)
-      maxY = Math.max(maxY, stageBlock.position_y + 1)
-    }
+  props.markerBlocks?.forEach(m => {
+    if (m.type !== 'entrance') return
+    if (m.position_x >= 0) { minX = Math.min(minX, m.position_x); maxX = Math.max(maxX, m.position_x) }
+    if (m.position_y >= 0) { minY = Math.min(minY, m.position_y); maxY = Math.max(maxY, m.position_y) }
   })
 
-  // Check block positions (0-based positioning)
-  props.blocks?.forEach(block => {
-    if (block.position_x >= 0 && block.position_y >= 0) {
-      maxX = Math.max(maxX, block.position_x + 1)
-      maxY = Math.max(maxY, block.position_y + 1)
-    }
-  })
-
-  // Minimum grid size
-  return {
-    cols: Math.max(maxX, 1),
-    rows: Math.max(maxY, 1)
+  if (!b.hasCols || !b.hasRows) {
+    return { cols: 1, rows: 1, offsetX: 0, offsetY: 0 }
   }
+  return { cols: maxX - minX + 1, rows: maxY - minY + 1, offsetX: minX, offsetY: minY }
 })
 
-// Create layout grid with blocks and stage positioned
 const layoutGrid = computed(() => {
-  const { rows, cols } = gridDimensions.value
+  const { rows, cols, offsetX, offsetY } = gridDimensions.value
   const grid = Array(rows).fill(null).map(() => Array(cols).fill(null))
 
-  // Place stage blocks (0-based positioning)
+  const inGrid = (col, row) => col >= 0 && col < cols && row >= 0 && row < rows
+
   props.stageBlocks?.forEach(stageBlock => {
-    const x = stageBlock.position_x
-    const y = stageBlock.position_y
-    if (x >= 0 && x < cols && y >= 0 && y < rows) {
-      grid[y][x] = { type: 'stage', name: stageBlock.name }
+    const col = stageBlock.position_x - offsetX
+    const row = stageBlock.position_y - offsetY
+    if (stageBlock.position_x >= 0 && stageBlock.position_y >= 0 && inGrid(col, row)) {
+      grid[row][col] = { type: 'stage', name: stageBlock.name }
     }
   })
 
-  // Place blocks that have valid positions (0-based positioning)
   props.blocks?.forEach(block => {
-    const x = block.position_x
-    const y = block.position_y
-    if (x >= 0 && x < cols && y >= 0 && y < rows) {
-      grid[y][x] = { type: 'block', ...block }
+    const col = block.position_x - offsetX
+    const row = block.position_y - offsetY
+    if (block.position_x >= 0 && block.position_y >= 0 && inGrid(col, row)) {
+      grid[row][col] = { type: 'block', ...block }
+    }
+  })
+
+  const bounds = blockBounds.value
+
+  props.markerBlocks?.forEach(marker => {
+    const { position_x: x, position_y: y, name } = marker
+
+    if (marker.type === 'comment') {
+      const col = x - offsetX
+      const row = y - offsetY
+      if (x >= 0 && y >= 0 && inGrid(col, row)) {
+        grid[row][col] = { type: 'comment', name }
+      }
+      return
+    }
+
+    const rotation = marker.rotation || 0
+
+    if (x === -1 && y >= 0 && bounds.hasCols && inGrid(0, y - offsetY)) {
+      placeEntrance('row', y - offsetY, bounds.minX - offsetX, bounds.maxX - bounds.minX + 1, name, rotation)
+    } else if (y === -1 && x >= 0 && bounds.hasRows && inGrid(x - offsetX, 0)) {
+      placeEntrance('column', x - offsetX, bounds.minY - offsetY, bounds.maxY - bounds.minY + 1, name, rotation)
     }
   })
 
   return grid
+
+  function placeEntrance(orientation, line, start, span, name, rotation) {
+    const cell = (offset) => orientation === 'row' ? [line, start + offset] : [start + offset, line]
+    const spanKey = orientation === 'row' ? 'colSpan' : 'rowSpan'
+
+    for (let i = 0; i < span; i++) {
+      const [r, c] = cell(i)
+      grid[r][c] = i === 0
+        ? { type: 'entrance', name, rotation, orientation, [spanKey]: span }
+        : { type: 'covered' }
+    }
+  }
 })
 
-// Get blocks that are positioned off-grid (for separate display)
-const unplacedBlocks = computed(() => {
-  const { rows, cols } = gridDimensions.value
-  return props.blocks?.filter(block =>
-    block.position_x < 0 || block.position_x >= cols ||
-    block.position_y < 0 || block.position_y >= rows ||
-    block.position_x == null || block.position_y == null
-  ) || []
+const blockBounds = computed(() => {
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity
+
+  const consider = (x, y) => {
+    if (x >= 0) { minX = Math.min(minX, x); maxX = Math.max(maxX, x) }
+    if (y >= 0) { minY = Math.min(minY, y); maxY = Math.max(maxY, y) }
+  }
+
+  props.blocks?.forEach(b => consider(b.position_x, b.position_y))
+  props.stageBlocks?.forEach(b => consider(b.position_x, b.position_y))
+  props.markerBlocks?.forEach(m => {
+    if (m.type === 'comment') consider(m.position_x, m.position_y)
+  })
+
+  return {
+    minX, maxX, minY, maxY,
+    hasCols: maxX >= minX,
+    hasRows: maxY >= minY
+  }
 })
 
-// Get seat status styling
-const getSeatStatus = (seat) => {
-  const seatId = seat.id
+const unplacedBlocks = computed(() =>
+  props.blocks?.filter(block => block.position_x < 0 || block.position_y < 0) || []
+)
 
-  if (props.bookedSeats.includes(seatId)) {
-    return { class: 'seat-booked', disabled: true }
-  }
-
-  if (selectedSeatIds.value.includes(seatId)) {
-    return { class: 'seat-selected', disabled: false }
-  }
-
-  return { class: 'seat-available', disabled: false }
-}
-
-// Handle seat click
 const handleSeatClick = (seat) => {
   const seatId = seat.id
 
@@ -120,7 +146,6 @@ const handleSeatClick = (seat) => {
   emit('seats-changed', [...selectedSeatIds.value])
 }
 
-// Handle booked seat click (admin only)
 const handleBookedSeatClick = (seat) => {
   emit('booked-seat-click', seat)
 }
@@ -186,30 +211,28 @@ watch(() => props.selectedSeats, (newSeats) => {
         <table class="seat-layout-table p-32 bg-white">
           <tbody>
             <tr v-for="(row, rowIndex) in layoutGrid" :key="rowIndex">
+              <template v-for="(cell, colIndex) in row" :key="colIndex">
               <td
-                v-for="(cell, colIndex) in row"
-                :key="colIndex"
+                v-if="!cell || cell.type !== 'covered'"
+                :colspan="cell?.colSpan || 1"
+                :rowspan="cell?.rowSpan || 1"
                 :class="[
                   'layout-cell',
-                  { 'stage-layout-cell': cell && cell.type === 'stage' }
+                  {
+                    'stage-layout-cell': cell && cell.type === 'stage',
+                    'entrance-layout-cell': cell && cell.type === 'entrance',
+                    'entrance-layout-row': cell && cell.type === 'entrance' && cell.orientation === 'row',
+                    'entrance-layout-column': cell && cell.type === 'entrance' && cell.orientation === 'column'
+                  }
                 ]"
               >
-                <!-- Empty Cell -->
                 <div v-if="cell === null" class="empty-cell"></div>
 
-                <!-- Stage Cell -->
-                <div
-                  v-else-if="cell.type === 'stage'"
-                  class="stage-text"
-                >
+                <div v-else-if="cell.type === 'stage'" class="stage-text">
                   {{ cell.name || 'STAGE' }}
                 </div>
 
-                <!-- Block Cell -->
-                <div
-                  v-else-if="cell.type === 'block'"
-                  class="block-cell"
-                >
+                <div v-else-if="cell.type === 'block'" class="block-cell">
                   <SeatBlock
                     :block="cell"
                     :booked-seats="bookedSeats"
@@ -219,7 +242,22 @@ watch(() => props.selectedSeats, (newSeats) => {
                     @booked-seat-click="handleBookedSeatClick"
                   />
                 </div>
+
+                <div
+                  v-else-if="cell.type === 'entrance'"
+                  class="entrance-text"
+                  :class="cell.orientation === 'column' ? 'entrance-column' : 'entrance-row'"
+                >
+                  <component :is="arrow(cell.rotation)" class="entrance-arrow" />
+                  <span class="entrance-label" :class="{ 'entrance-label-flip': cell.rotation === 270 }">{{ cell.name || 'ENTRANCE' }}</span>
+                  <component :is="arrow(cell.rotation)" class="entrance-arrow" />
+                </div>
+
+                <div v-else-if="cell.type === 'comment'" class="comment-text">
+                  {{ cell.name }}
+                </div>
               </td>
+              </template>
             </tr>
           </tbody>
         </table>
@@ -272,7 +310,6 @@ watch(() => props.selectedSeats, (newSeats) => {
   border-radius: 8px;
 }
 
-/* Layout Container */
 .layout-container {
   overflow: hidden; /* Panzoom handles overflow */
   margin-bottom: 20px;
@@ -308,7 +345,6 @@ watch(() => props.selectedSeats, (newSeats) => {
   height: auto;
 }
 
-/* Stage Layout Cell - apply styling directly to the table cell */
 .stage-layout-cell {
   background: linear-gradient(45deg, #e5e7eb 25%, transparent 25%),
               linear-gradient(-45deg, #e5e7eb 25%, transparent 25%),
@@ -328,39 +364,19 @@ watch(() => props.selectedSeats, (newSeats) => {
   min-width: 200px;
 }
 
-/* Stage Text */
-.stage-text {
-  color: #6b7280;
-  font-weight: bold;
-  font-size: 14px;
-  letter-spacing: 0.1em;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  min-height: 60px;
-  min-width: 200px;
+.entrance-layout-cell {
+  position: relative;
+  padding: 8px;
 }
 
-/* Empty Cell */
-.empty-cell {
-  width: 100%;
-  height: 100%;
-  background: transparent;
+.entrance-layout-row {
+  height: 76px;
 }
 
-/* Block Cell */
-.block-cell {
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  overflow: visible;
+.entrance-layout-column {
+  min-width: 76px;
 }
 
-/* Unplaced Blocks */
 .unplaced-blocks {
   margin-top: 20px;
   padding: 16px;
@@ -382,7 +398,6 @@ watch(() => props.selectedSeats, (newSeats) => {
   gap: 16px;
 }
 
-/* Legend */
 .seat-legend {
   display: flex;
   justify-content: center;
@@ -407,6 +422,89 @@ watch(() => props.selectedSeats, (newSeats) => {
   margin: 0;
 }
 
-/* Remove responsive styles - layout should never distort */
-/* The layout maintains its exact proportions and becomes scrollable if needed */
+.empty-cell {
+  width: 100%;
+  height: 100%;
+  background: transparent;
+}
+
+.stage-text {
+  color: #6b7280;
+  font-weight: bold;
+  font-size: 14px;
+  letter-spacing: 0.1em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  min-height: 60px;
+  min-width: 200px;
+}
+
+.block-cell {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+.entrance-text {
+  position: absolute;
+  inset: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background-color: #fef3c7;
+  border: 2px dashed #f59e0b;
+  border-radius: 6px;
+  color: #92400e;
+  font-weight: bold;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  user-select: none;
+}
+
+.entrance-arrow {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+.entrance-column {
+  flex-direction: column;
+}
+
+.entrance-column .entrance-label {
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+}
+
+.entrance-column .entrance-label-flip {
+  transform: rotate(180deg);
+}
+
+.comment-text {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  min-height: 60px;
+  padding: 6px;
+  background-color: #f3f4f6;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  color: #1f2937;
+  font-size: 12px;
+  font-weight: 600;
+  text-align: center;
+  white-space: normal;
+  word-break: break-word;
+  user-select: none;
+}
 </style>

--- a/resources/js/Components/SeatLayout.vue
+++ b/resources/js/Components/SeatLayout.vue
@@ -114,8 +114,10 @@ const blockBounds = computed(() => {
   let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity
 
   const consider = (x: number, y: number) => {
-    if (x >= 0) { minX = Math.min(minX, x); maxX = Math.max(maxX, x) }
-    if (y >= 0) { minY = Math.min(minY, y); maxY = Math.max(maxY, y) }
+    if (x >= 0 && y >= 0) {
+      minX = Math.min(minX, x); maxX = Math.max(maxX, x)
+      minY = Math.min(minY, y); maxY = Math.max(maxY, y)
+    }
   }
 
   props.blocks?.forEach(b => consider(b.position_x, b.position_y))

--- a/resources/js/Components/SeatLayout.vue
+++ b/resources/js/Components/SeatLayout.vue
@@ -3,7 +3,13 @@ import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import Panzoom from '@panzoom/panzoom'
 import SeatBlock from './SeatBlock.vue'
 import { ArrowUp, ArrowRight, ArrowDown, ArrowLeft } from 'lucide-vue-next'
-import type { LayoutBlock, PropStageBlock, PropMarkerBlock } from '@/types/layout'
+import type { LayoutBlock, PropStageBlock, PropMarkerBlock, Orientation } from '@/types/layout'
+
+interface GridCellNamed { type: 'stage' | 'comment'; name: string; colSpan?: number; rowSpan?: number }
+interface GridCellBlock extends LayoutBlock { type: 'block'; colSpan?: number; rowSpan?: number }
+interface GridCellEntrance { type: 'entrance'; name: string; rotation: number; orientation: Orientation; colSpan?: number; rowSpan?: number }
+interface GridCellCovered { type: 'covered' }
+type GridCell = GridCellNamed | GridCellBlock | GridCellEntrance | GridCellCovered
 
 const arrow = (rotation: number | undefined) =>
   ({ 0: ArrowUp, 90: ArrowRight, 180: ArrowDown, 270: ArrowLeft }[rotation ?? 0] || ArrowUp)
@@ -52,7 +58,7 @@ const gridDimensions = computed(() => {
 
 const layoutGrid = computed(() => {
   const { rows, cols, offsetX, offsetY } = gridDimensions.value
-  const grid = Array(rows).fill(null).map(() => Array(cols).fill(null))
+  const grid: (GridCell | null)[][] = Array(rows).fill(null).map(() => Array(cols).fill(null))
 
   const inGrid = (col: number, row: number) => col >= 0 && col < cols && row >= 0 && row < rows
 
@@ -95,9 +101,49 @@ const layoutGrid = computed(() => {
     }
   })
 
+  mergeAdjacentCells('stage')
+  mergeAdjacentCells('comment')
+
   return grid
 
-  function placeEntrance(orientation: string, line: number, start: number, span: number, name: string, rotation: number) {
+  function isCandidate(cell: GridCell | null | undefined, ref: GridCellNamed): cell is GridCellNamed {
+    return cell?.type === ref.type && (cell as GridCellNamed)?.name === ref.name
+  }
+
+  function rowMatchesSpan(r: number, c: number, colSpan: number, ref: GridCellNamed) {
+    for (let dc = 0; dc < colSpan; dc++) {
+      if (!isCandidate(grid[r]?.[c + dc], ref)) return false
+    }
+    return true
+  }
+
+  function mergeAdjacentCells(type: GridCellNamed['type']) {
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        const cell = grid[r][c]
+        if (cell?.type !== type) continue
+
+        const ref: GridCellNamed = { type, name: (cell as GridCellNamed).name }
+
+        let colSpan = 1
+        while (c + colSpan < cols && isCandidate(grid[r][c + colSpan], ref)) colSpan++
+
+        let rowSpan = 1
+        while (r + rowSpan < rows && rowMatchesSpan(r + rowSpan, c, colSpan, ref)) rowSpan++
+
+        for (let dr = 0; dr < rowSpan; dr++) {
+          for (let dc = 0; dc < colSpan; dc++) {
+            if (dr === 0 && dc === 0) continue
+            grid[r + dr][c + dc] = { type: 'covered' }
+          }
+        }
+
+        grid[r][c] = { ...ref, colSpan, rowSpan }
+      }
+    }
+  }
+
+  function placeEntrance(orientation: Orientation, line: number, start: number, span: number, name: string, rotation: number) {
     const cell = (offset: number) => orientation === 'row' ? [line, start + offset] : [start + offset, line]
     const spanKey = orientation === 'row' ? 'colSpan' : 'rowSpan'
 
@@ -228,7 +274,7 @@ watch(() => props.selectedSeats, (newSeats) => {
               >
                 <div v-if="cell === null" class="empty-cell"></div>
 
-                <div v-else-if="cell.type === 'stage'" class="stage-text">
+                <div v-else-if="cell.type === 'stage'" class="stage-text" :style="{ minWidth: `${(cell.colSpan ?? 1) * 200}px`, minHeight: `${(cell.rowSpan ?? 1) * 60}px` }">
                   {{ cell.name || 'STAGE' }}
                 </div>
 
@@ -253,7 +299,7 @@ watch(() => props.selectedSeats, (newSeats) => {
                   <component :is="arrow(cell.rotation)" class="entrance-arrow" />
                 </div>
 
-                <div v-else-if="cell.type === 'comment'" class="comment-text">
+                <div v-else-if="cell.type === 'comment'" class="comment-text" :style="{ minWidth: `${(cell.colSpan ?? 1) * 60}px`, minHeight: `${(cell.rowSpan ?? 1) * 60}px` }">
                   {{ cell.name }}
                 </div>
               </td>

--- a/resources/js/Components/SeatLayout.vue
+++ b/resources/js/Components/SeatLayout.vue
@@ -1,34 +1,38 @@
-<script setup>
+<script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import Panzoom from '@panzoom/panzoom'
 import SeatBlock from './SeatBlock.vue'
 import { ArrowUp, ArrowRight, ArrowDown, ArrowLeft } from 'lucide-vue-next'
+import type { LayoutBlock, PropStageBlock, PropMarkerBlock } from '@/types/layout'
 
-const arrow = (rotation) => ({ 0: ArrowUp, 90: ArrowRight, 180: ArrowDown, 270: ArrowLeft }[rotation] || ArrowUp)
+const arrow = (rotation: number | undefined) =>
+  ({ 0: ArrowUp, 90: ArrowRight, 180: ArrowDown, 270: ArrowLeft }[rotation ?? 0] || ArrowUp)
 
-const props = defineProps({
-  event: Object,
-  room: Object,
-  blocks: Array,
-  stageBlocks: Array,
-  markerBlocks: {
-    type: Array,
-    default: () => []
-  },
-  selectedSeats: Array,
-  bookedSeats: Array,
-  adminMode: {
-    type: Boolean,
-    default: false
-  }
+interface Props {
+  event?: object
+  room?: object
+  blocks?: LayoutBlock[]
+  stageBlocks?: PropStageBlock[]
+  markerBlocks?: PropMarkerBlock[]
+  selectedSeats?: number[]
+  bookedSeats?: number[]
+  adminMode?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  markerBlocks: () => [],
+  adminMode: false,
 })
 
-const emit = defineEmits(['seats-changed', 'booked-seat-click'])
+const emit = defineEmits<{
+  'seats-changed': [seats: number[]]
+  'booked-seat-click': [seat: { id: number }]
+}>()
 
-const selectedSeatIds = ref([...props.selectedSeats])
+const selectedSeatIds = ref<number[]>([...(props.selectedSeats ?? [])])
 
-const panzoomContainer = ref(null)
-const panzoomInstance = ref(null)
+const panzoomContainer = ref<HTMLElement | null>(null)
+const panzoomInstance = ref<ReturnType<typeof Panzoom> | null>(null)
 
 const gridDimensions = computed(() => {
   const b = blockBounds.value
@@ -50,7 +54,7 @@ const layoutGrid = computed(() => {
   const { rows, cols, offsetX, offsetY } = gridDimensions.value
   const grid = Array(rows).fill(null).map(() => Array(cols).fill(null))
 
-  const inGrid = (col, row) => col >= 0 && col < cols && row >= 0 && row < rows
+  const inGrid = (col: number, row: number) => col >= 0 && col < cols && row >= 0 && row < rows
 
   props.stageBlocks?.forEach(stageBlock => {
     const col = stageBlock.position_x - offsetX
@@ -93,8 +97,8 @@ const layoutGrid = computed(() => {
 
   return grid
 
-  function placeEntrance(orientation, line, start, span, name, rotation) {
-    const cell = (offset) => orientation === 'row' ? [line, start + offset] : [start + offset, line]
+  function placeEntrance(orientation: string, line: number, start: number, span: number, name: string, rotation: number) {
+    const cell = (offset: number) => orientation === 'row' ? [line, start + offset] : [start + offset, line]
     const spanKey = orientation === 'row' ? 'colSpan' : 'rowSpan'
 
     for (let i = 0; i < span; i++) {
@@ -109,7 +113,7 @@ const layoutGrid = computed(() => {
 const blockBounds = computed(() => {
   let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity
 
-  const consider = (x, y) => {
+  const consider = (x: number, y: number) => {
     if (x >= 0) { minX = Math.min(minX, x); maxX = Math.max(maxX, x) }
     if (y >= 0) { minY = Math.min(minY, y); maxY = Math.max(maxY, y) }
   }
@@ -131,10 +135,10 @@ const unplacedBlocks = computed(() =>
   props.blocks?.filter(block => block.position_x < 0 || block.position_y < 0) || []
 )
 
-const handleSeatClick = (seat) => {
+const handleSeatClick = (seat: { id: number }) => {
   const seatId = seat.id
 
-  if (props.bookedSeats.includes(seatId)) return
+  if (props.bookedSeats?.includes(seatId)) return
 
   const index = selectedSeatIds.value.indexOf(seatId)
   if (index > -1) {
@@ -146,37 +150,33 @@ const handleSeatClick = (seat) => {
   emit('seats-changed', [...selectedSeatIds.value])
 }
 
-const handleBookedSeatClick = (seat) => {
+const handleBookedSeatClick = (seat: { id: number }) => {
   emit('booked-seat-click', seat)
 }
 
 
-// Initialize Panzoom
 onMounted(() => {
-  // Use nextTick to ensure DOM is fully rendered
   nextTick(() => {
     if (panzoomContainer.value) {
-      const panzoomContent = panzoomContainer.value.querySelector('.panzoom-content')
+      const panzoomContent = panzoomContainer.value.querySelector<HTMLElement>('.panzoom-content')
       if (panzoomContent) {
         try {
           panzoomInstance.value = Panzoom(panzoomContent, {
             maxScale: 3,
             minScale: 0.2,
-            startScale: 0.2, // Default zoom-out scale
+            startScale: 0.2,
             contain: 'outside',
             cursor: 'grab',
             panOnlyWhenZoomed: false,
-            excludeClass: 'seat', // Don't pan when clicking seats
-            handleStartEvent: (event) => {
-              // Allow seat clicks to work normally
-              if (event.target.classList.contains('seat')) {
+            excludeClass: 'seat',
+            handleStartEvent: (event: Event) => {
+              if ((event.target as Element).classList.contains('seat')) {
                 return false
               }
               return true
             }
           })
 
-          // Add mouse wheel zoom to container
           panzoomContainer.value.addEventListener('wheel', (event) => {
             if (panzoomInstance.value) {
               panzoomInstance.value.zoomWithWheel(event)
@@ -190,16 +190,14 @@ onMounted(() => {
   })
 })
 
-// Cleanup Panzoom
 onUnmounted(() => {
   if (panzoomInstance.value) {
     panzoomInstance.value.destroy()
   }
 })
 
-// Watch for external seat selection changes
 watch(() => props.selectedSeats, (newSeats) => {
-  selectedSeatIds.value = [...newSeats]
+  selectedSeatIds.value = [...(newSeats ?? [])]
 }, { immediate: true })
 </script>
 
@@ -235,7 +233,7 @@ watch(() => props.selectedSeats, (newSeats) => {
                 <div v-else-if="cell.type === 'block'" class="block-cell">
                   <SeatBlock
                     :block="cell"
-                    :booked-seats="bookedSeats"
+                    :booked-seats="bookedSeats || []"
                     :selected-seats="selectedSeatIds"
                     :admin-mode="adminMode"
                     @seat-click="handleSeatClick"
@@ -270,7 +268,7 @@ watch(() => props.selectedSeats, (newSeats) => {
               v-for="block in unplacedBlocks"
               :key="`unplaced-${block.id}`"
               :block="block"
-              :booked-seats="bookedSeats"
+              :booked-seats="bookedSeats || []"
               :selected-seats="selectedSeatIds"
               :admin-mode="adminMode"
               @seat-click="handleSeatClick"

--- a/resources/js/Pages/Admin/EventShow.vue
+++ b/resources/js/Pages/Admin/EventShow.vue
@@ -27,6 +27,7 @@ const props = defineProps({
     room: Object,
     blocks: Array,
     stageBlocks: Array,
+    markerBlocks: { type: Array, default: () => [] },
     bookings: Array,
     bookedSeats: Array,
     seatBookingMap: Object,
@@ -500,7 +501,7 @@ onMounted(scrollToHighlightedBooking)
                     </div>
                     <div class="flex items-center">
                         <Users class="h-4 w-4 mr-1"/>
-                        {{ bookings.total || bookings.length }} bookings
+                        {{ bookings.total ?? bookings.length }} bookings
                     </div>
                 </div>
                 <div class="flex flex-col items-end gap-1">
@@ -586,6 +587,7 @@ onMounted(scrollToHighlightedBooking)
                             :room="room"
                             :blocks="blocks"
                             :stage-blocks="stageBlocks"
+                            :marker-blocks="markerBlocks"
                             :booked-seats="bookedSeats"
                             :selected-seats="selectedSeats"
                             @seats-changed="handleSeatsChanged"

--- a/resources/js/Pages/Admin/RoomLayout/Edit.vue
+++ b/resources/js/Pages/Admin/RoomLayout/Edit.vue
@@ -375,9 +375,14 @@ const toBlockPayload = (b: FormBlock): BlockPayload => ({
 // Use server provided ids for new blocks
 const applyBlockIdMap = () => {
   const map = props.blockIdMap || {}
-  form.blocks.forEach(block => {
-    if (map[block.id] != null) block.id = map[block.id]
-  })
+  const remap = (list: Array<{ id: BlockId }>) => {
+    list.forEach(block => {
+      if (map[block.id] != null) block.id = map[block.id]
+    })
+  }
+  remap(form.stageBlocks)
+  remap(form.markerBlocks)
+  remap(form.blocks)
 }
 
 const showSaveError = (errors: Record<string, string>) => {

--- a/resources/js/Pages/Admin/RoomLayout/Edit.vue
+++ b/resources/js/Pages/Admin/RoomLayout/Edit.vue
@@ -7,8 +7,11 @@ import { Card } from '@/Components/ui/card'
 import { Input } from '@/Components/ui/input'
 import { Label } from '@/Components/ui/label'
 import { useToast } from '@/Components/ui/toast'
+import { Trash2, RotateCw, ArrowUp, ArrowRight, ArrowDown, ArrowLeft, TriangleAlert } from 'lucide-vue-next'
 
 defineOptions({ layout: AdminLayout })
+
+const DEFAULT_SEAT_COUNT = 25
 
 const { error: errorToast } = useToast()
 
@@ -20,6 +23,7 @@ const props = defineProps({
   },
   blocks: Array,
   stageBlocks: Array,
+  markerBlocks: { type: Array, default: () => [] },
   blockIdMap: { type: Object, default: () => ({}) },
   title: String,
   breadcrumbs: Array
@@ -27,16 +31,17 @@ const props = defineProps({
 
 let tempBlockCounter = 0
 
-// Layout grid size (HTML table cells)
 const GRID_ROWS = 8
 const GRID_COLS = 12
 
-// Helper functions that need to be available during initialization
+// Shared skeleton for a placed cell in the layout grid; type-specific colors/rings are added per branch.
+const CELL_BASE = 'w-full h-full border rounded cursor-pointer flex flex-col items-center justify-center text-center hover:shadow-md transition-shadow'
+
 const getOriginalSeatingBlock = (blockId) => {
   return props.blocks.find(block => block.id === blockId)
 }
 
-// Build complete form data from props with all editing capabilities
+// Build complete form data
 const form = useForm({
   stageBlocks: props.stageBlocks.map(block => ({
     id: block.id,
@@ -44,10 +49,18 @@ const form = useForm({
     position_x: block.position_x != null ? block.position_x : -1,
     position_y: block.position_y != null ? block.position_y : -1
   })),
+  markerBlocks: props.markerBlocks.map(block => ({
+    id: block.id,
+    type: block.type,
+    name: block.name,
+    position_x: block.position_x != null ? block.position_x : -1,
+    position_y: block.position_y != null ? block.position_y : -1,
+    orientation: block.type === 'entrance' && block.position_y === -1 ? 'column' : 'row',
+    rotation: block.rotation || 0
+  })),
   blocks: props.blocks.map(block => {
     const originalBlock = getOriginalSeatingBlock(block.id)
 
-    // Build row data for each block
     const rows = []
     const rowCount = originalBlock?.rows?.length || 10
 
@@ -77,7 +90,7 @@ const form = useForm({
 
 // UI State
 const selectedBlock = ref(null)
-const selectedBlockType = ref(null) // 'stage' or 'seating'
+const selectedBlockType = ref(null) // 'stage' or 'seating' or 'comment' or 'entrance'
 const expandedBlocks = ref(new Set())
 const showNewBlockDialog = ref(false)
 const newBlockName = ref('')
@@ -97,11 +110,20 @@ const canConfirmDelete = computed(
 )
 
 
-// Create empty grid with block assignments
+const markerOrientation = (marker) => (marker.position_y === -1 ? 'column' : 'row')
+
+const markerCells = (marker) => {
+  const { position_x: x, position_y: y } = marker
+  if (marker.type === 'comment') return [[y, x]]
+  if (markerOrientation(marker) === 'column') {
+    return Array.from({ length: GRID_ROWS }, (_, r) => [r, x])
+  }
+  return Array.from({ length: GRID_COLS }, (_, c) => [y, c])
+}
+
 const layoutGrid = computed(() => {
   const grid = Array(GRID_ROWS).fill(null).map(() => Array(GRID_COLS).fill(null))
 
-  // Place stage blocks
   form.stageBlocks.forEach(stageBlock => {
     const x = stageBlock.position_x
     const y = stageBlock.position_y
@@ -110,7 +132,6 @@ const layoutGrid = computed(() => {
     }
   })
 
-  // Place seating blocks
   form.blocks.forEach(block => {
     const x = block.position_x
     const y = block.position_y
@@ -119,36 +140,34 @@ const layoutGrid = computed(() => {
     }
   })
 
+  form.markerBlocks.forEach((marker, index) => {
+    const cell = { ...marker, markerIndex: index, orientation: markerOrientation(marker) }
+    for (const [y, x] of markerCells(marker)) {
+      if (grid[y]?.[x] === null) grid[y][x] = cell
+    }
+  })
+
   return grid
 })
 
-// Helper function to check if block is placed
-const getBlockPlacementStatus = (block) => {
-  return block.position_x >= 0 && block.position_x < GRID_COLS &&
-         block.position_y >= 0 && block.position_y < GRID_ROWS &&
-         block.position_x != null && block.position_y != null
-}
+// Placed blocks always sit inside the fixed grid; -1 on either axis means unplaced.
+const getBlockPlacementStatus = (block) => block.position_x >= 0 && block.position_y >= 0
 
-
-
-// Get total seats from the block's row data
 const getTotalSeats = (block) => {
   if (!block.rows || block.rows.length === 0) return 0
   return block.rows.reduce((total, row) => total + (row.seatCount || 0), 0)
 }
 
-// Get orientation arrow
 const getOrientationArrow = (rotation) => {
   const arrows = {
-    0: '↑',    // Up (toward top)
-    90: '→',   // Right
-    180: '↓',  // Down
-    270: '←'   // Left
+    0: ArrowUp,
+    90: ArrowRight,
+    180: ArrowDown,
+    270: ArrowLeft
   }
-  return arrows[rotation] || '↑'
+  return arrows[rotation] || ArrowUp
 }
 
-// Block management functions
 const toggleBlockExpanded = (blockId) => {
   if (expandedBlocks.value.has(blockId)) {
     expandedBlocks.value.delete(blockId)
@@ -166,67 +185,104 @@ const selectBlock = (block, type) => {
   selectedBlockType.value = type
 }
 
-
-// Grid cell click handlers
 const handleCellClick = (rowIndex, colIndex) => {
-  // Check if cell is empty
-  if (layoutGrid.value[rowIndex][colIndex] === null) {
-    // If we have a selected block, move it here
-    if (selectedBlock.value && selectedBlockType.value) {
-      if (selectedBlockType.value === 'stage') {
-        updateStageBlockPosition(selectedBlock.value.id, colIndex, rowIndex)
-      } else {
-        updateSeatingBlockPosition(selectedBlock.value.id, colIndex, rowIndex)
-      }
-    }
+  const block = selectedBlock.value
+  const type = selectedBlockType.value
+  if (!block || !type) return
+
+  if (type === 'marker' && block.type === 'entrance') {
+    return placeMarker(block.markerIndex, rowIndex, colIndex)
   }
+  if (layoutGrid.value[rowIndex][colIndex] !== null) return
+
+  if (type === 'stage') setPosition(form.stageBlocks, block.id, colIndex, rowIndex)
+  else if (type === 'marker') placeMarker(block.markerIndex, rowIndex, colIndex)
+  else setPosition(form.blocks, block.id, colIndex, rowIndex)
 }
 
-// Position management
-const updateSeatingBlockPosition = (blockId, x, y) => {
-  const blockIndex = form.blocks.findIndex(block => block.id === blockId)
-  if (blockIndex !== -1) {
-    form.blocks[blockIndex].position_x = x
-    form.blocks[blockIndex].position_y = y
-  }
+const setPosition = (list, id, x, y) => {
+  const target = list.find(b => b.id === id)
+  if (target) Object.assign(target, { position_x: x, position_y: y })
 }
 
-const updateStageBlockPosition = (stageBlockId, x, y) => {
-  const stageBlockIndex = form.stageBlocks.findIndex(block => block.id === stageBlockId)
-  if (stageBlockIndex !== -1) {
-    form.stageBlocks[stageBlockIndex].position_x = x
-    form.stageBlocks[stageBlockIndex].position_y = y
-  }
+const placeMarker = (markerIndex, rowIndex, colIndex) => {
+  const marker = form.markerBlocks[markerIndex]
+  if (!marker) return
+  if (marker.type === 'comment') Object.assign(marker, { position_x: colIndex, position_y: rowIndex })
+  else if (marker.orientation === 'column') Object.assign(marker, { position_x: colIndex, position_y: -1 })
+  else Object.assign(marker, { position_x: -1, position_y: rowIndex })
 }
 
-// Rotate seating block
 const rotateBlock = (blockId) => {
-  const blockIndex = form.blocks.findIndex(block => block.id === blockId)
-  if (blockIndex !== -1) {
-    const currentRotation = form.blocks[blockIndex].rotation
-    form.blocks[blockIndex].rotation = (currentRotation + 90) % 360
-  }
+  const block = form.blocks.find(b => b.id === blockId)
+  if (block) block.rotation = (block.rotation + 90) % 360
 }
 
-// Add new stage block
 const addStageBlock = () => {
-  const nextSort = form.stageBlocks.length
   form.stageBlocks.push({
-    id: null, // Will be created on save
-    name: `Stage ${nextSort + 1}`,
+    id: null,
+    name: `Stage ${form.stageBlocks.length + 1}`,
     position_x: -1,
     position_y: -1
   })
 }
 
-// Remove stage block
 const removeStageBlock = (index) => {
   if (confirm('Are you sure you want to remove this stage block?')) {
     form.stageBlocks.splice(index, 1)
   }
 }
 
-// Delete seating block
+const ENTRANCE_DIRECTIONS = {
+  row: [180, 0],
+  column: [90, 270]
+}
+
+const addMarker = (type) => {
+  const base = { id: null, type, position_x: -1, position_y: -1 }
+  if (type === 'comment') {
+    form.markerBlocks.push({ ...base, name: 'Note' })
+    return
+  }
+  const count = form.markerBlocks.filter(m => m.type === 'entrance').length
+  form.markerBlocks.push({
+    ...base,
+    name: count === 0 ? 'Entrance' : `Entrance ${count + 1}`,
+    orientation: 'row',
+    rotation: ENTRANCE_DIRECTIONS.row[0]
+  })
+}
+
+const setEntranceOrientation = (marker, orientation) => {
+  Object.assign(marker, {
+    orientation,
+    rotation: ENTRANCE_DIRECTIONS[orientation][0],
+    position_x: -1,
+    position_y: -1
+  })
+}
+
+const rotateEntrance = (marker) => {
+  const directions = ENTRANCE_DIRECTIONS[marker.orientation]
+  const current = directions.indexOf(marker.rotation)
+  marker.rotation = directions[(current + 1) % directions.length]
+}
+
+const removeMarkerBlock = (index) => {
+  if (confirm('Are you sure you want to remove this marker?')) {
+    if (selectedBlockType.value === 'marker' && selectedBlock.value?.markerIndex === index) {
+      selectedBlock.value = null
+      selectedBlockType.value = null
+    }
+    form.markerBlocks.splice(index, 1)
+  }
+}
+
+const getMarkerPlacementStatus = (marker) => {
+  if (marker.type === 'comment') return getBlockPlacementStatus(marker)
+  return marker.orientation === 'column' ? marker.position_x >= 0 : marker.position_y >= 0
+}
+
 const deleteSeatingBlock = (blockId) => {
   if (confirm('Are you sure you want to delete this block? This will permanently remove all rows and seats in this block.')) {
     const deleteForm = useForm({})
@@ -234,7 +290,6 @@ const deleteSeatingBlock = (blockId) => {
     deleteForm.delete(route('admin.rooms.blocks.delete', { room: props.room.id, block: blockId }), {
       preserveScroll: true,
       onSuccess: () => {
-        // Remove the block from the form data after successful deletion
         const index = form.blocks.findIndex(b => b.id === blockId)
         if (index !== -1) {
           form.blocks.splice(index, 1)
@@ -244,11 +299,8 @@ const deleteSeatingBlock = (blockId) => {
   }
 }
 
-// Track form submission state
 const isSubmitting = ref(false)
 
-// Entry point for the Save button: if the room has bookings, require explicit
-// confirmation (typing the phrase) before proceeding, since saving deletes them.
 const requestSaveLayout = () => {
   if (hasBookings.value) {
     deleteBookingsConfirmText.value = ''
@@ -264,16 +316,23 @@ const confirmDeleteBookingsAndSave = () => {
   saveLayout()
 }
 
-// Save all changes
 const saveLayout = () => {
   isSubmitting.value = true
-  // Build form data with row data for blocks that have rows configured
+  // Build form data
   const formData = {
     stageBlocks: form.stageBlocks.map(stageBlock => ({
       id: stageBlock.id,
       name: stageBlock.name,
       position_x: stageBlock.position_x,
       position_y: stageBlock.position_y
+    })),
+    markerBlocks: form.markerBlocks.map(marker => ({
+      id: marker.id,
+      type: marker.type,
+      name: marker.name,
+      position_x: marker.position_x,
+      position_y: marker.position_y,
+      rotation: marker.rotation ?? 0
     })),
     blocks: form.blocks.map(block => {
       const formattedBlock = {
@@ -297,8 +356,6 @@ const saveLayout = () => {
       return formattedBlock
     })
   }
-
-  console.log('Submitting form data:', formData)
 
   // Create a new form instance with the data and submit
   const submitForm = useForm(formData)
@@ -364,10 +421,10 @@ const createNewBlock = () => {
     position_y: y,
     rotation: 0,
     rowCount: 10,
-    defaultSeatsPerRow: 25,
+    defaultSeatsPerRow: DEFAULT_SEAT_COUNT,
     rows: Array.from({ length: 10 }, (_, i) => ({
       rowNumber: i + 1,
-      seatCount: 25,
+      seatCount: DEFAULT_SEAT_COUNT,
       isCustom: false,
       alignment: 'center'
     }))
@@ -376,12 +433,11 @@ const createNewBlock = () => {
   closeNewBlockDialog()
 }
 
-// Row management functions
 const addRow = (block) => {
   const newRowNumber = block.rows.length + 1
   block.rows.push({
     rowNumber: newRowNumber,
-    seatCount: 25, // Default seat count
+    seatCount: DEFAULT_SEAT_COUNT,
     isCustom: false,
     alignment: 'center'
   })
@@ -395,20 +451,16 @@ const removeRow = (block) => {
 
 const removeSpecificRow = (block, rowNumber) => {
   if (block.rows.length > 1) {
-    // Remove the specific row
     const index = block.rows.findIndex(row => row.rowNumber === rowNumber)
     if (index !== -1) {
       block.rows.splice(index, 1)
 
-      // Renumber all remaining rows to maintain sequential order
       block.rows.forEach((row, idx) => {
         row.rowNumber = idx + 1
       })
     }
   }
 }
-
-
 </script>
 
 <template>
@@ -421,7 +473,7 @@ const removeSpecificRow = (block, rowNumber) => {
       v-if="hasBookings"
       class="mb-6 flex items-start gap-3 rounded-md border border-red-300 bg-red-50 p-4 text-red-800"
     >
-      <span class="text-xl leading-none">⚠️</span>
+      <TriangleAlert class="w-5 h-5 flex-shrink-0 mt-0.5" />
       <div class="text-sm">
         <p class="font-semibold">Saving will delete all bookings for this room.</p>
         <p class="mt-1">
@@ -437,10 +489,9 @@ const removeSpecificRow = (block, rowNumber) => {
       <!-- Left Column: Stage & Block Management -->
       <div class="lg:col-span-2 space-y-4">
 
-        <!-- Stage Blocks Management -->
-        <Card class="p-4">
-          <div class="flex justify-between items-center mb-4">
-            <h3 class="font-semibold">🎭 Stage Blocks</h3>
+        <Card class="p-4 gap-0">
+          <div class="flex justify-between items-center mb-2">
+            <h3 class="font-semibold">Stage Blocks</h3>
             <Button size="sm" variant="outline" class="text-xs" @click="addStageBlock">
               + Add Stage
             </Button>
@@ -454,7 +505,7 @@ const removeSpecificRow = (block, rowNumber) => {
               :class="{ 'ring-2 ring-inset ring-red-500': selectedBlock?.id === stageBlock.id && selectedBlockType === 'stage' }"
             >
               <div @click="selectBlock(stageBlock, 'stage')" class="cursor-pointer">
-                <div class="flex items-center justify-between mb-2">
+                <div class="flex items-end justify-between mb-2">
                   <div class="flex-1">
                     <Label class="text-xs">Stage Name</Label>
                     <Input
@@ -468,8 +519,9 @@ const removeSpecificRow = (block, rowNumber) => {
                     variant="destructive"
                     @click.stop="removeStageBlock(index)"
                     class="text-xs px-2 py-1 ml-2"
+                    title="Remove stage"
                   >
-                    🗑
+                    <Trash2 class="w-4 h-4" />
                   </Button>
                 </div>
 
@@ -482,9 +534,96 @@ const removeSpecificRow = (block, rowNumber) => {
           </div>
         </Card>
 
+        <!-- Marker Blocks Management -->
+        <Card class="p-4 gap-0">
+          <div class="flex justify-between items-center mb-2">
+            <h3 class="font-semibold">Markers</h3>
+            <div class="flex gap-1">
+              <Button size="sm" variant="outline" class="text-xs" @click="addMarker('entrance')">
+                + Entrance
+              </Button>
+              <Button size="sm" variant="outline" class="text-xs" @click="addMarker('comment')">
+                + Comment
+              </Button>
+            </div>
+          </div>
+
+          <div class="space-y-2 max-h-96 overflow-y-auto">
+            <div
+              v-for="(marker, index) in form.markerBlocks"
+              :key="`marker-${marker.id || 'new'}-${index}`"
+              class="border border-gray-200 rounded-lg p-3"
+              :class="{ 'ring-2 ring-inset ring-amber-500': selectedBlockType === 'marker' && selectedBlock?.markerIndex === index }"
+              @click="selectBlock({ ...marker, markerIndex: index }, 'marker')"
+            >
+              <div class="flex items-end justify-between mb-2">
+                <div class="flex-1">
+                  <Label class="text-xs">
+                    {{ marker.type === 'entrance' ? 'Entrance label' : 'Comment text' }}
+                  </Label>
+                  <Input
+                    v-model="marker.name"
+                    class="text-sm mt-1"
+                    @click.stop
+                  />
+                </div>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  @click.stop="removeMarkerBlock(index)"
+                  class="text-xs px-2 py-1 ml-2"
+                  title="Remove marker"
+                >
+                  <Trash2 class="w-4 h-4" />
+                </Button>
+              </div>
+
+              <div v-if="marker.type === 'entrance'" class="space-y-2 mb-2">
+                <div class="flex items-center gap-2">
+                  <Label class="text-xs w-16">Spans</Label>
+                  <select
+                    :value="marker.orientation"
+                    @click.stop
+                    @change="setEntranceOrientation(marker, $event.target.value)"
+                    class="text-xs h-7 border border-gray-300 rounded px-2 flex-1"
+                  >
+                    <option value="row">Full row (horizontal)</option>
+                    <option value="column">Full column (vertical)</option>
+                  </select>
+                </div>
+                <div class="flex items-center gap-2">
+                  <Label class="text-xs w-16">Direction</Label>
+                  <component :is="getOrientationArrow(marker.rotation)" class="w-5 h-5" />
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    @click.stop="rotateEntrance(marker)"
+                    class="text-xs px-2 py-1"
+                    title="Rotate direction"
+                  >
+                    <RotateCw class="w-4 h-4" />
+                  </Button>
+                </div>
+              </div>
+
+              <div class="text-xs text-gray-500">
+                <span v-if="getMarkerPlacementStatus(marker)" class="text-green-600">
+                  <template v-if="marker.type === 'comment'">• Placed ({{ marker.position_y }}, {{ marker.position_x }})</template>
+                  <template v-else-if="marker.orientation === 'column'">• Column {{ marker.position_x }}</template>
+                  <template v-else>• Row {{ marker.position_y }}</template>
+                </span>
+                <span v-else class="text-orange-600">• Not placed</span>
+              </div>
+            </div>
+            <p v-if="form.markerBlocks.length === 0" class="text-xs text-gray-400">
+              No markers yet. Add an entrance row/column or a comment note.
+            </p>
+          </div>
+        </Card>
+
         <!-- Seating Blocks Management -->
-        <Card class="p-4">
-          <div class="flex justify-between items-center mb-4">
+        <Card class="p-4 gap-0">
+          <div class="flex justify-between items-center mb-2">
             <h3 class="font-semibold">Seating Blocks</h3>
             <Button size="sm" variant="outline" class="text-xs" @click="openNewBlockDialog">
               + Add Block
@@ -526,98 +665,90 @@ const removeSpecificRow = (block, rowNumber) => {
                   </div>
                 </div>
                 <div class="flex items-center space-x-2">
-                  <span class="text-lg">{{ getOrientationArrow(block.rotation) }}</span>
+                  <component :is="getOrientationArrow(block.rotation)" class="w-5 h-5" />
                   <Button
                     size="sm"
                     variant="outline"
                     @click.stop="rotateBlock(block.id)"
                     class="text-xs px-2 py-1"
+                    title="Rotate block"
                   >
-                    ↻
+                    <RotateCw class="w-4 h-4" />
                   </Button>
                   <Button
                     size="sm"
                     variant="destructive"
                     @click.stop="deleteSeatingBlock(block.id)"
                     class="text-xs px-2 py-1"
+                    title="Delete block"
                   >
-                    🗑
+                    <Trash2 class="w-4 h-4" />
                   </Button>
                 </div>
               </div>
 
-              <!-- Block Details (Expandable) -->
               <div v-if="isBlockExpanded(block.id)" class="border-t bg-gray-50 p-3">
-
-                <!-- Row Configuration -->
-                <div>
-                  <div class="flex justify-between items-center mb-2">
-                    <Label class="text-xs">Row Configuration ({{ block.rows.length }} rows)</Label>
-                    <div class="flex gap-1">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        @click="addRow(block)"
-                        class="text-xs px-2 py-1"
-                        title="Add row"
-                      >
-                        + Row
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        @click="removeRow(block)"
-                        :disabled="block.rows.length <= 1"
-                        class="text-xs px-2 py-1"
-                        title="Remove last row"
-                      >
-                        - Row
-                      </Button>
-                    </div>
-                  </div>
-                  <div class="space-y-1 max-h-60 overflow-y-auto">
-                    <div
-                      v-for="row in block.rows"
-                      :key="row.rowNumber"
-                      class="flex items-center gap-2 px-3 py-2 bg-white border border-gray-200 rounded text-xs"
+                <div class="flex justify-between items-center mb-2">
+                  <Label class="text-xs">Row Configuration ({{ block.rows.length }} rows)</Label>
+                  <div class="flex gap-1">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      @click="addRow(block)"
+                      class="text-xs px-2 py-1"
+                      title="Add row"
                     >
-                      <!-- Row Number -->
-                      <span class="font-medium w-12">Row {{ row.rowNumber }}</span>
+                      + Row
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      @click="removeRow(block)"
+                      :disabled="block.rows.length <= 1"
+                      class="text-xs px-2 py-1"
+                      title="Remove last row"
+                    >
+                      - Row
+                    </Button>
+                  </div>
+                </div>
+                <div class="space-y-1 max-h-60 overflow-y-auto">
+                  <div
+                    v-for="row in block.rows"
+                    :key="row.rowNumber"
+                    class="flex items-center gap-2 px-3 py-2 bg-white border border-gray-200 rounded text-xs"
+                  >
+                    <span class="font-medium w-12">Row {{ row.rowNumber }}</span>
 
-                      <!-- Seat Count Input -->
-                      <Input
-                        v-model.number="row.seatCount"
-                        type="number"
-                        min="1"
-                        max="100"
-                        class="text-xs h-7 w-16"
-                      />
+                    <Input
+                      v-model.number="row.seatCount"
+                      type="number"
+                      min="1"
+                      max="100"
+                      class="text-xs h-7 w-16"
+                    />
 
-                      <!-- Alignment Select -->
-                      <select
-                        v-model="row.alignment"
-                        class="text-xs h-7 border border-gray-300 rounded px-2 flex-1"
-                      >
-                        <option value="left">Left</option>
-                        <option value="center">Center</option>
-                        <option value="right">Right</option>
-                      </select>
+                    <select
+                      v-model="row.alignment"
+                      class="text-xs h-7 border border-gray-300 rounded px-2 flex-1"
+                    >
+                      <option value="left">Left</option>
+                      <option value="center">Center</option>
+                      <option value="right">Right</option>
+                    </select>
 
-                      <!-- Seat Count Display -->
-                      <span class="text-gray-500 w-16">{{ row.seatCount }} seats</span>
+                    <span class="text-gray-500 w-16">{{ row.seatCount }} seats</span>
 
-                      <!-- Delete Button -->
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        @click="removeSpecificRow(block, row.rowNumber)"
-                        :disabled="block.rows.length <= 1"
-                        class="text-xs px-1 py-0 h-6 w-6 text-red-600 hover:bg-red-50 flex-shrink-0"
-                        title="Delete this row"
-                      >
-                        ×
-                      </Button>
-                    </div>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      @click="removeSpecificRow(block, row.rowNumber)"
+                      :disabled="block.rows.length <= 1"
+                      class="text-xs px-1 py-0 h-6 w-6 text-red-600 hover:bg-red-50 flex-shrink-0"
+                      title="Delete this row"
+                    >
+                      ×
+                    </Button>
                   </div>
                 </div>
               </div>
@@ -628,13 +759,13 @@ const removeSpecificRow = (block, rowNumber) => {
 
       <!-- Main Layout Table -->
       <div class="lg:col-span-3">
-        <Card class="p-6">
+        <Card class="p-6 gap-0">
           <div class="mb-4">
             <h3 class="font-semibold text-center text-lg mb-2">
               Room Layout Grid
             </h3>
             <div class="text-center text-sm text-gray-600 mb-4">
-              Click empty cells to place selected blocks • Multiple stages supported
+              Click empty cells to place selected blocks
             </div>
           </div>
 
@@ -650,42 +781,52 @@ const removeSpecificRow = (block, rowNumber) => {
                     :class="{
                       'bg-gray-50': cell === null,
                       'bg-red-100': cell?.type === 'stage',
-                      'bg-blue-50': cell?.type === 'seating'
+                      'bg-blue-50': cell?.type === 'seating',
+                      'bg-amber-50': cell?.type === 'entrance',
+                      'bg-yellow-50': cell?.type === 'comment'
                     }"
                     @click="handleCellClick(rowIndex, colIndex)"
                   >
-                    <!-- Empty Cell -->
                     <div v-if="cell === null" class="w-full h-full flex items-center justify-center text-gray-400 text-xs">
                       {{ rowIndex }},{{ colIndex }}
                     </div>
 
-                    <!-- Stage Cell -->
                     <div
                       v-else-if="cell.type === 'stage'"
-                      class="w-full h-full bg-red-600 text-white border border-red-700 rounded cursor-pointer flex flex-col items-center justify-center text-center hover:shadow-md transition-shadow"
+                      :class="[CELL_BASE, 'bg-red-600 text-white border-red-700', { 'ring-2 ring-red-300': selectedBlock?.id === cell.id && selectedBlockType === 'stage' }]"
                       @click.stop="selectBlock(cell, 'stage')"
-                      :class="{ 'ring-2 ring-red-300': selectedBlock?.id === cell.id && selectedBlockType === 'stage' }"
                     >
-                      <div class="font-bold text-sm">🎭</div>
                       <div class="font-medium text-xs">{{ cell.name }}</div>
                     </div>
 
-                    <!-- Seating Block Cell -->
                     <div
                       v-else-if="cell.type === 'seating'"
+                      :class="[CELL_BASE, 'bg-white border-gray-400', { 'ring-2 ring-blue-500 bg-blue-50': selectedBlock?.id === cell.id && selectedBlockType === 'seating' }]"
                       @click.stop="selectBlock(cell, 'seating')"
-                      class="w-full h-full bg-white border border-gray-400 rounded cursor-pointer flex flex-col items-center justify-center text-center hover:shadow-md transition-shadow"
-                      :class="{ 'ring-2 ring-blue-500 bg-blue-50': selectedBlock?.id === cell.id && selectedBlockType === 'seating' }"
                     >
-                      <!-- Block Title -->
                       <div class="font-medium text-xs mb-1 px-1">{{ cell.name }}</div>
 
-                      <!-- Orientation Arrow -->
-                      <div class="text-lg mb-1">{{ getOrientationArrow(cell.rotation) }}</div>
+                      <component :is="getOrientationArrow(cell.rotation)" class="w-5 h-5 mb-1" />
 
-                      <!-- Seat Count -->
                       <div class="text-xs text-gray-600">{{ getTotalSeats(cell) }} seats</div>
                       <div class="text-xs text-gray-500">{{ cell.rows?.length || 0 }} rows</div>
+                    </div>
+
+                    <div
+                      v-else-if="cell.type === 'entrance'"
+                      :class="[CELL_BASE, 'bg-amber-500 text-white border-amber-600', { 'ring-2 ring-amber-300': selectedBlockType === 'marker' && selectedBlock?.markerIndex === cell.markerIndex }]"
+                      @click.stop="selectBlock({ ...cell }, 'marker')"
+                    >
+                      <component :is="getOrientationArrow(cell.rotation)" class="w-4 h-4" />
+                      <div class="font-medium text-xs px-1">{{ cell.name }}</div>
+                    </div>
+
+                    <div
+                      v-else-if="cell.type === 'comment'"
+                      :class="[CELL_BASE, 'bg-yellow-100 text-yellow-900 border-yellow-400 p-1', { 'ring-2 ring-amber-400': selectedBlockType === 'marker' && selectedBlock?.markerIndex === cell.markerIndex }]"
+                      @click.stop="selectBlock({ ...cell }, 'marker')"
+                    >
+                      <div class="text-xs whitespace-normal break-words">{{ cell.name }}</div>
                     </div>
                   </td>
                 </tr>
@@ -694,12 +835,22 @@ const removeSpecificRow = (block, rowNumber) => {
           </div>
 
           <!-- Grid Legend -->
-          <div class="mt-4 text-xs text-gray-500 text-center">
-            Grid coordinates: Row,Column • 🎭 Red = Stages • Blue = Seating Blocks • Click empty cells to place selected blocks
+          <div class="mt-4 flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs text-gray-500">
+            <span class="flex items-center gap-1.5">
+              <span class="inline-block w-3 h-3 rounded-sm bg-red-600"></span>Stages
+            </span>
+            <span class="flex items-center gap-1.5">
+              <span class="inline-block w-3 h-3 rounded-sm bg-blue-50 border border-gray-400"></span>Seating
+            </span>
+            <span class="flex items-center gap-1.5">
+              <span class="inline-block w-3 h-3 rounded-sm bg-amber-500"></span>Entrances
+            </span>
+            <span class="flex items-center gap-1.5">
+              <span class="inline-block w-3 h-3 rounded-sm bg-yellow-100 border border-yellow-400"></span>Comments
+            </span>
           </div>
         </Card>
 
-        <!-- Single Save Button -->
         <div class="mt-6 flex justify-center">
           <Button
             @click="requestSaveLayout"
@@ -715,7 +866,6 @@ const removeSpecificRow = (block, rowNumber) => {
     </div>
   </div>
 
-  <!-- Delete Bookings Confirmation Dialog -->
   <div v-if="showDeleteBookingsDialog" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
     <div class="bg-white p-6 rounded-lg shadow-xl max-w-md w-full mx-4">
       <h3 class="text-lg font-semibold mb-2 text-red-700">Delete all bookings?</h3>
@@ -754,7 +904,6 @@ const removeSpecificRow = (block, rowNumber) => {
     </div>
   </div>
 
-  <!-- New Block Dialog -->
   <div v-if="showNewBlockDialog" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
     <div class="bg-white p-6 rounded-lg shadow-xl max-w-md w-full mx-4">
       <h3 class="text-lg font-semibold mb-4">Create New Seating Block</h3>
@@ -797,7 +946,6 @@ const removeSpecificRow = (block, rowNumber) => {
 </template>
 
 <style scoped>
-/* Layout Table Styling */
 .layout-table {
   min-width: 800px;
 }
@@ -813,7 +961,6 @@ const removeSpecificRow = (block, rowNumber) => {
   background-color: #f0f9ff !important;
 }
 
-/* Block in cell styling */
 .layout-cell .bg-white {
   transition: all 0.2s ease;
 }
@@ -823,13 +970,11 @@ const removeSpecificRow = (block, rowNumber) => {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
-/* Orientation arrow styling */
 .text-lg {
   line-height: 1;
   font-weight: bold;
 }
 
-/* Responsive adjustments */
 @media (max-width: 1024px) {
   .layout-table {
     min-width: 600px;

--- a/resources/js/Pages/Admin/RoomLayout/Edit.vue
+++ b/resources/js/Pages/Admin/RoomLayout/Edit.vue
@@ -37,6 +37,7 @@ const props = withDefaults(defineProps<{
 })
 
 let tempBlockCounter = 0
+const nextTempKey = (): string => `temp-${++tempBlockCounter}`
 
 const GRID_ROWS = 8
 const GRID_COLS = 12
@@ -58,15 +59,21 @@ const stageFromProp = (block: PropStageBlock): FormStageBlock => ({
   position_y: pos(block.position_y)
 })
 
-const markerFromProp = (block: PropMarkerBlock): FormMarkerBlock => ({
-  id: block.id,
-  type: block.type,
-  name: block.name,
-  position_x: pos(block.position_x),
-  position_y: pos(block.position_y),
-  orientation: block.type === 'entrance' && block.position_y === -1 ? 'column' : 'row',
-  rotation: block.rotation || 0
-})
+const markerFromProp = (block: PropMarkerBlock): FormMarkerBlock => {
+  const x = pos(block.position_x)
+  const y = pos(block.position_y)
+  let orientation: Orientation = 'row'
+  if (block.type === 'entrance') {
+    if (x === -1 && y === -1) {
+      // cant figure at axis, so use the rotation to get some semblance of it
+      const r = block.rotation ?? 0
+      orientation = (r === 90 || r === 270) ? 'column' : 'row'
+    } else {
+      orientation = y === -1 ? 'column' : 'row'
+    }
+  }
+  return { id: block.id, type: block.type, name: block.name, position_x: x, position_y: y, orientation, rotation: block.rotation || 0 }
+}
 
 const rowsFromBlock = (block: PropBlock | null): FormRow[] => {
   const rowCount = block?.rows?.length || DEFAULT_ROW_COUNT
@@ -199,7 +206,7 @@ const handleCellClick = (rowIndex: number, colIndex: number) => {
   else setPosition(form.blocks, block.id, colIndex, rowIndex)
 }
 
-const setPosition = (list: Array<{ id: BlockId | null, position_x: number, position_y: number }>, id: BlockId, x: number, y: number) => {
+const setPosition = (list: Array<{ id: BlockId, position_x: number, position_y: number }>, id: BlockId, x: number, y: number) => {
   const target = list.find(b => b.id === id)
   if (target) Object.assign(target, { position_x: x, position_y: y })
 }
@@ -207,9 +214,18 @@ const setPosition = (list: Array<{ id: BlockId | null, position_x: number, posit
 const placeMarker = (markerIndex: number, rowIndex: number, colIndex: number) => {
   const marker = form.markerBlocks[markerIndex]
   if (!marker) return
-  if (marker.type === 'comment') Object.assign(marker, { position_x: colIndex, position_y: rowIndex })
-  else if (marker.orientation === 'column') Object.assign(marker, { position_x: colIndex, position_y: -1 })
-  else Object.assign(marker, { position_x: -1, position_y: rowIndex })
+  if (marker.type === 'comment') {
+    Object.assign(marker, { position_x: colIndex, position_y: rowIndex })
+    return
+  }
+  const others = form.markerBlocks.filter((_, i) => i !== markerIndex)
+  if (marker.orientation === 'column') {
+    if (others.some(m => m.orientation === 'column' && m.position_x === colIndex)) return
+    Object.assign(marker, { position_x: colIndex, position_y: -1 })
+  } else {
+    if (others.some(m => m.orientation === 'row' && m.position_y === rowIndex)) return
+    Object.assign(marker, { position_x: -1, position_y: rowIndex })
+  }
 }
 
 const rotateBlock = (blockId: BlockId) => {
@@ -219,7 +235,7 @@ const rotateBlock = (blockId: BlockId) => {
 
 const addStageBlock = () => {
   form.stageBlocks.push({
-    id: null,
+    id: nextTempKey(),
     name: `Stage ${form.stageBlocks.length + 1}`,
     ...UNPLACED
   })
@@ -237,17 +253,19 @@ const ENTRANCE_DIRECTIONS: Record<Orientation, number[]> = {
 }
 
 const addMarker = (type: MarkerType) => {
-  const base = { id: null, type, ...UNPLACED }
+  const id = nextTempKey()
   if (type === 'comment') {
-    form.markerBlocks.push({ ...base, name: 'Note' })
+    form.markerBlocks.push({ id, type, name: 'Note', ...UNPLACED })
     return
   }
   const count = form.markerBlocks.filter(m => m.type === 'entrance').length
   form.markerBlocks.push({
-    ...base,
+    id,
+    type,
     name: count === 0 ? 'Entrance' : `Entrance ${count + 1}`,
     orientation: 'row',
-    rotation: ENTRANCE_DIRECTIONS.row[0]
+    rotation: ENTRANCE_DIRECTIONS.row[0],
+    ...UNPLACED
   })
 }
 
@@ -420,7 +438,7 @@ const createNewBlock = () => {
   const { x, y } = nextFreeCell.value
 
   form.blocks.push({
-    id: `temp-${++tempBlockCounter}`,
+    id: nextTempKey(),
     name,
     position_x: x,
     position_y: y,
@@ -471,7 +489,7 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
       v-if="hasBookings"
       class="mb-6 flex items-start gap-3 rounded-md border border-red-300 bg-red-50 p-4 text-red-800"
     >
-      <TriangleAlert class="w-5 h-5 flex-shrink-0 mt-0.5" />
+      <TriangleAlert class="w-5 h-5 shrink-0 mt-0.5" />
       <div class="text-sm">
         <p class="font-semibold">Saving will delete all bookings for this room.</p>
         <p class="mt-1">
@@ -498,7 +516,7 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
           <div class="space-y-2 max-h-96 overflow-y-auto">
             <div
               v-for="(stageBlock, index) in form.stageBlocks"
-              :key="`stage-${stageBlock.id || index}`"
+              :key="stageBlock.id"
               class="border border-gray-200 rounded-lg p-3"
               :class="{ 'ring-2 ring-inset ring-red-500': selectedBlock?.id === stageBlock.id && selectedBlockType === 'stage' }"
             >
@@ -549,7 +567,7 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
           <div class="space-y-2 max-h-96 overflow-y-auto">
             <div
               v-for="(marker, index) in form.markerBlocks"
-              :key="`marker-${marker.id || 'new'}-${index}`"
+              :key="marker.id"
               class="border border-gray-200 rounded-lg p-3"
               :class="{ 'ring-2 ring-inset ring-amber-500': selectedBlockType === 'marker' && selectedBlock?.markerIndex === index }"
               @click="selectBlock({ ...marker, markerIndex: index }, 'marker')"
@@ -742,7 +760,7 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
                       variant="ghost"
                       @click="removeSpecificRow(block, row.rowNumber)"
                       :disabled="block.rows.length <= 1"
-                      class="text-xs px-1 py-0 h-6 w-6 text-red-600 hover:bg-red-50 flex-shrink-0"
+                      class="text-xs px-1 py-0 h-6 w-6 text-red-600 hover:bg-red-50 shrink-0"
                       title="Delete this row"
                     >
                       ×

--- a/resources/js/Pages/Admin/RoomLayout/Edit.vue
+++ b/resources/js/Pages/Admin/RoomLayout/Edit.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script setup lang="ts">
 import { ref, computed, nextTick } from 'vue'
 import { Head, useForm } from '@inertiajs/vue3'
 import AdminLayout from '@/Admin/Layouts/AdminLayout.vue'
@@ -8,25 +8,32 @@ import { Input } from '@/Components/ui/input'
 import { Label } from '@/Components/ui/label'
 import { useToast } from '@/Components/ui/toast'
 import { Trash2, RotateCw, ArrowUp, ArrowRight, ArrowDown, ArrowLeft, TriangleAlert } from 'lucide-vue-next'
+import type {
+  BlockId, Orientation, MarkerType,
+  PropBlock, PropStageBlock, PropMarkerBlock,
+  FormBlock, FormStageBlock, FormMarkerBlock, FormRow
+} from '@/types/layout'
 
 defineOptions({ layout: AdminLayout })
 
 const DEFAULT_SEAT_COUNT = 25
+const DEFAULT_ROW_COUNT = 10
 
 const { error: errorToast } = useToast()
 
-const props = defineProps({
-  room: Object,
-  bookingsCount: {
-    type: Number,
-    default: 0
-  },
-  blocks: Array,
-  stageBlocks: Array,
-  markerBlocks: { type: Array, default: () => [] },
-  blockIdMap: { type: Object, default: () => ({}) },
-  title: String,
-  breadcrumbs: Array
+const props = withDefaults(defineProps<{
+  room: { id: number, name: string }
+  bookingsCount?: number
+  blocks: PropBlock[]
+  stageBlocks: PropStageBlock[]
+  markerBlocks?: PropMarkerBlock[]
+  blockIdMap?: Record<string, number>
+  title: string
+  breadcrumbs?: Array<{ title: string, url: string | null }>
+}>(), {
+  bookingsCount: 0,
+  markerBlocks: () => [],
+  blockIdMap: () => ({})
 })
 
 let tempBlockCounter = 0
@@ -34,64 +41,65 @@ let tempBlockCounter = 0
 const GRID_ROWS = 8
 const GRID_COLS = 12
 
-// Shared skeleton for a placed cell in the layout grid; type-specific colors/rings are added per branch.
+const UNPLACED = { position_x: -1, position_y: -1 }
+
+const inGrid = (x: number, y: number) => x >= 0 && x < GRID_COLS && y >= 0 && y < GRID_ROWS
+
+const isPlaced = (block: { position_x: number, position_y: number }) => block.position_x >= 0 && block.position_y >= 0
+
 const CELL_BASE = 'w-full h-full border rounded cursor-pointer flex flex-col items-center justify-center text-center hover:shadow-md transition-shadow'
 
-const getOriginalSeatingBlock = (blockId) => {
-  return props.blocks.find(block => block.id === blockId)
-}
+const pos = (value: number | null | undefined) => (value != null ? value : -1)
 
-// Build complete form data
-const form = useForm({
-  stageBlocks: props.stageBlocks.map(block => ({
-    id: block.id,
-    name: block.name,
-    position_x: block.position_x != null ? block.position_x : -1,
-    position_y: block.position_y != null ? block.position_y : -1
-  })),
-  markerBlocks: props.markerBlocks.map(block => ({
-    id: block.id,
-    type: block.type,
-    name: block.name,
-    position_x: block.position_x != null ? block.position_x : -1,
-    position_y: block.position_y != null ? block.position_y : -1,
-    orientation: block.type === 'entrance' && block.position_y === -1 ? 'column' : 'row',
-    rotation: block.rotation || 0
-  })),
-  blocks: props.blocks.map(block => {
-    const originalBlock = getOriginalSeatingBlock(block.id)
-
-    const rows = []
-    const rowCount = originalBlock?.rows?.length || 10
-
-    for (let i = 1; i <= rowCount; i++) {
-      const existingRow = originalBlock?.rows?.find((r, idx) => idx + 1 === i)
-      rows.push({
-        rowNumber: i,
-        seatCount: existingRow?.seats_count || 25,
-        isCustom: existingRow?.custom_seat_count !== null && existingRow?.custom_seat_count !== undefined,
-        alignment: existingRow?.alignment || 'center'
-      })
-    }
-
-    return {
-      id: block.id,
-      name: block.name,
-      position_x: block.position_x != null ? block.position_x : -1,
-      position_y: block.position_y != null ? block.position_y : -1,
-      rotation: block.rotation || 0,
-      rowCount: rowCount,
-      defaultSeatsPerRow: 25,
-      rows: rows,
-      originalData: originalBlock
-    }
-  })
+const stageFromProp = (block: PropStageBlock): FormStageBlock => ({
+  id: block.id,
+  name: block.name,
+  position_x: pos(block.position_x),
+  position_y: pos(block.position_y)
 })
 
-// UI State
-const selectedBlock = ref(null)
-const selectedBlockType = ref(null) // 'stage' or 'seating' or 'comment' or 'entrance'
-const expandedBlocks = ref(new Set())
+const markerFromProp = (block: PropMarkerBlock): FormMarkerBlock => ({
+  id: block.id,
+  type: block.type,
+  name: block.name,
+  position_x: pos(block.position_x),
+  position_y: pos(block.position_y),
+  orientation: block.type === 'entrance' && block.position_y === -1 ? 'column' : 'row',
+  rotation: block.rotation || 0
+})
+
+const rowsFromBlock = (block: PropBlock | null): FormRow[] => {
+  const rowCount = block?.rows?.length || DEFAULT_ROW_COUNT
+  return Array.from({ length: rowCount }, (_, i) => {
+    const existingRow = block?.rows?.[i]
+    return {
+      rowNumber: i + 1,
+      seatCount: existingRow?.seats_count || DEFAULT_SEAT_COUNT,
+      isCustom: existingRow?.custom_seat_count != null,
+      alignment: existingRow?.alignment || 'center'
+    }
+  })
+}
+
+const blockFromProp = (block: PropBlock): FormBlock => ({
+  id: block.id,
+  name: block.name,
+  position_x: pos(block.position_x),
+  position_y: pos(block.position_y),
+  rotation: block.rotation || 0,
+  rows: rowsFromBlock(block)
+})
+
+const form = useForm({
+  stageBlocks: props.stageBlocks.map(stageFromProp),
+  markerBlocks: props.markerBlocks.map(markerFromProp),
+  blocks: props.blocks.map(blockFromProp)
+})
+
+type SelectedType = 'stage' | 'seating' | 'marker'
+const selectedBlock = ref<any>(null)
+const selectedBlockType = ref<SelectedType | null>(null)
+const expandedBlocks = ref<Set<BlockId>>(new Set())
 const showNewBlockDialog = ref(false)
 const newBlockName = ref('')
 
@@ -110,9 +118,9 @@ const canConfirmDelete = computed(
 )
 
 
-const markerOrientation = (marker) => (marker.position_y === -1 ? 'column' : 'row')
+const markerOrientation = (marker: FormMarkerBlock): Orientation => (marker.position_y === -1 ? 'column' : 'row')
 
-const markerCells = (marker) => {
+const markerCells = (marker: FormMarkerBlock): Array<[number, number]> => {
   const { position_x: x, position_y: y } = marker
   if (marker.type === 'comment') return [[y, x]]
   if (markerOrientation(marker) === 'column') {
@@ -125,19 +133,13 @@ const layoutGrid = computed(() => {
   const grid = Array(GRID_ROWS).fill(null).map(() => Array(GRID_COLS).fill(null))
 
   form.stageBlocks.forEach(stageBlock => {
-    const x = stageBlock.position_x
-    const y = stageBlock.position_y
-    if (x >= 0 && x < GRID_COLS && y >= 0 && y < GRID_ROWS) {
-      grid[y][x] = { type: 'stage', ...stageBlock }
-    }
+    const { position_x: x, position_y: y } = stageBlock
+    if (inGrid(x, y)) grid[y][x] = { type: 'stage', ...stageBlock }
   })
 
   form.blocks.forEach(block => {
-    const x = block.position_x
-    const y = block.position_y
-    if (x >= 0 && x < GRID_COLS && y >= 0 && y < GRID_ROWS) {
-      grid[y][x] = { type: 'seating', ...block }
-    }
+    const { position_x: x, position_y: y } = block
+    if (inGrid(x, y)) grid[y][x] = { type: 'seating', ...block }
   })
 
   form.markerBlocks.forEach((marker, index) => {
@@ -150,25 +152,22 @@ const layoutGrid = computed(() => {
   return grid
 })
 
-// Placed blocks always sit inside the fixed grid; -1 on either axis means unplaced.
-const getBlockPlacementStatus = (block) => block.position_x >= 0 && block.position_y >= 0
-
-const getTotalSeats = (block) => {
+const getTotalSeats = (block: FormBlock) => {
   if (!block.rows || block.rows.length === 0) return 0
   return block.rows.reduce((total, row) => total + (row.seatCount || 0), 0)
 }
 
-const getOrientationArrow = (rotation) => {
-  const arrows = {
+const getOrientationArrow = (rotation: number | undefined) => {
+  const arrows: Record<number, typeof ArrowUp> = {
     0: ArrowUp,
     90: ArrowRight,
     180: ArrowDown,
     270: ArrowLeft
   }
-  return arrows[rotation] || ArrowUp
+  return (rotation != null && arrows[rotation]) || ArrowUp
 }
 
-const toggleBlockExpanded = (blockId) => {
+const toggleBlockExpanded = (blockId: BlockId) => {
   if (expandedBlocks.value.has(blockId)) {
     expandedBlocks.value.delete(blockId)
   } else {
@@ -176,16 +175,16 @@ const toggleBlockExpanded = (blockId) => {
   }
 }
 
-const isBlockExpanded = (blockId) => {
+const isBlockExpanded = (blockId: BlockId) => {
   return expandedBlocks.value.has(blockId)
 }
 
-const selectBlock = (block, type) => {
+const selectBlock = (block: any, type: SelectedType) => {
   selectedBlock.value = block
   selectedBlockType.value = type
 }
 
-const handleCellClick = (rowIndex, colIndex) => {
+const handleCellClick = (rowIndex: number, colIndex: number) => {
   const block = selectedBlock.value
   const type = selectedBlockType.value
   if (!block || !type) return
@@ -200,12 +199,12 @@ const handleCellClick = (rowIndex, colIndex) => {
   else setPosition(form.blocks, block.id, colIndex, rowIndex)
 }
 
-const setPosition = (list, id, x, y) => {
+const setPosition = (list: Array<{ id: BlockId | null, position_x: number, position_y: number }>, id: BlockId, x: number, y: number) => {
   const target = list.find(b => b.id === id)
   if (target) Object.assign(target, { position_x: x, position_y: y })
 }
 
-const placeMarker = (markerIndex, rowIndex, colIndex) => {
+const placeMarker = (markerIndex: number, rowIndex: number, colIndex: number) => {
   const marker = form.markerBlocks[markerIndex]
   if (!marker) return
   if (marker.type === 'comment') Object.assign(marker, { position_x: colIndex, position_y: rowIndex })
@@ -213,7 +212,7 @@ const placeMarker = (markerIndex, rowIndex, colIndex) => {
   else Object.assign(marker, { position_x: -1, position_y: rowIndex })
 }
 
-const rotateBlock = (blockId) => {
+const rotateBlock = (blockId: BlockId) => {
   const block = form.blocks.find(b => b.id === blockId)
   if (block) block.rotation = (block.rotation + 90) % 360
 }
@@ -222,24 +221,23 @@ const addStageBlock = () => {
   form.stageBlocks.push({
     id: null,
     name: `Stage ${form.stageBlocks.length + 1}`,
-    position_x: -1,
-    position_y: -1
+    ...UNPLACED
   })
 }
 
-const removeStageBlock = (index) => {
+const removeStageBlock = (index: number) => {
   if (confirm('Are you sure you want to remove this stage block?')) {
     form.stageBlocks.splice(index, 1)
   }
 }
 
-const ENTRANCE_DIRECTIONS = {
+const ENTRANCE_DIRECTIONS: Record<Orientation, number[]> = {
   row: [180, 0],
   column: [90, 270]
 }
 
-const addMarker = (type) => {
-  const base = { id: null, type, position_x: -1, position_y: -1 }
+const addMarker = (type: MarkerType) => {
+  const base = { id: null, type, ...UNPLACED }
   if (type === 'comment') {
     form.markerBlocks.push({ ...base, name: 'Note' })
     return
@@ -253,22 +251,21 @@ const addMarker = (type) => {
   })
 }
 
-const setEntranceOrientation = (marker, orientation) => {
+const setEntranceOrientation = (marker: FormMarkerBlock, orientation: Orientation) => {
   Object.assign(marker, {
     orientation,
     rotation: ENTRANCE_DIRECTIONS[orientation][0],
-    position_x: -1,
-    position_y: -1
+    ...UNPLACED
   })
 }
 
-const rotateEntrance = (marker) => {
-  const directions = ENTRANCE_DIRECTIONS[marker.orientation]
-  const current = directions.indexOf(marker.rotation)
+const rotateEntrance = (marker: FormMarkerBlock) => {
+  const directions = ENTRANCE_DIRECTIONS[marker.orientation ?? 'row']
+  const current = directions.indexOf(marker.rotation ?? directions[0])
   marker.rotation = directions[(current + 1) % directions.length]
 }
 
-const removeMarkerBlock = (index) => {
+const removeMarkerBlock = (index: number) => {
   if (confirm('Are you sure you want to remove this marker?')) {
     if (selectedBlockType.value === 'marker' && selectedBlock.value?.markerIndex === index) {
       selectedBlock.value = null
@@ -278,12 +275,12 @@ const removeMarkerBlock = (index) => {
   }
 }
 
-const getMarkerPlacementStatus = (marker) => {
-  if (marker.type === 'comment') return getBlockPlacementStatus(marker)
+const getMarkerPlacementStatus = (marker: FormMarkerBlock) => {
+  if (marker.type === 'comment') return isPlaced(marker)
   return marker.orientation === 'column' ? marker.position_x >= 0 : marker.position_y >= 0
 }
 
-const deleteSeatingBlock = (blockId) => {
+const deleteSeatingBlock = (blockId: BlockId) => {
   if (confirm('Are you sure you want to delete this block? This will permanently remove all rows and seats in this block.')) {
     const deleteForm = useForm({})
 
@@ -316,72 +313,80 @@ const confirmDeleteBookingsAndSave = () => {
   saveLayout()
 }
 
-const saveLayout = () => {
-  isSubmitting.value = true
-  // Build form data
-  const formData = {
-    stageBlocks: form.stageBlocks.map(stageBlock => ({
-      id: stageBlock.id,
-      name: stageBlock.name,
-      position_x: stageBlock.position_x,
-      position_y: stageBlock.position_y
-    })),
-    markerBlocks: form.markerBlocks.map(marker => ({
-      id: marker.id,
-      type: marker.type,
-      name: marker.name,
-      position_x: marker.position_x,
-      position_y: marker.position_y,
-      rotation: marker.rotation ?? 0
-    })),
-    blocks: form.blocks.map(block => {
-      const formattedBlock = {
-        id: block.id,
-        name: block.name,
-        position_x: block.position_x,
-        position_y: block.position_y,
-        rotation: block.rotation
-      }
+const toStagePayload = (s: FormStageBlock) => ({
+  id: s.id,
+  name: s.name,
+  position_x: s.position_x,
+  position_y: s.position_y
+})
 
-      // Include row data if block has rows configured
-      if (block.rows && block.rows.length > 0) {
-        formattedBlock.rowsData = block.rows.map(row => ({
-          rowNumber: row.rowNumber,
-          seatCount: row.seatCount,
-          isCustom: row.isCustom,
-          alignment: row.alignment
-        }))
-      }
+const toMarkerPayload = (m: FormMarkerBlock) => ({
+  id: m.id,
+  type: m.type,
+  name: m.name,
+  position_x: m.position_x,
+  position_y: m.position_y,
+  rotation: m.rotation ?? 0
+})
 
-      return formattedBlock
-    })
-  }
+const toRowPayload = (r: FormRow) => ({
+  rowNumber: r.rowNumber,
+  seatCount: r.seatCount,
+  isCustom: r.isCustom,
+  alignment: r.alignment
+})
 
-  // Create a new form instance with the data and submit
-  const submitForm = useForm(formData)
-  submitForm.put(route('admin.rooms.layout.update', props.room.id), {
-    onSuccess: () => {
-      isSubmitting.value = false
-      const map = props.blockIdMap || {}
-      form.blocks.forEach(block => {
-        if (map[block.id] != null) {
-          block.id = map[block.id]
-        }
-      })
-    },
-    onError: (errors) => {
-      isSubmitting.value = false
-      const messages = Object.values(errors)
-      errorToast(
-        'Layout could not be saved',
-        messages.length ? messages.join('\n') : 'Please reload the page or try again.'
-      )
-    }
+interface BlockPayload {
+  id: BlockId
+  name: string
+  position_x: number
+  position_y: number
+  rotation: number
+  rowsData: ReturnType<typeof toRowPayload>[] // always >= 1 row; seeded on load, guarded on removal
+}
+
+const toBlockPayload = (b: FormBlock): BlockPayload => ({
+  id: b.id,
+  name: b.name,
+  position_x: b.position_x,
+  position_y: b.position_y,
+  rotation: b.rotation,
+  rowsData: b.rows.map(toRowPayload)
+})
+
+// Use server provided ids for new blocks
+const applyBlockIdMap = () => {
+  const map = props.blockIdMap || {}
+  form.blocks.forEach(block => {
+    if (map[block.id] != null) block.id = map[block.id]
   })
 }
 
-// Create new seating block
-const newBlockNameInput = ref(null)
+const showSaveError = (errors: Record<string, string>) => {
+  const messages = Object.values(errors)
+  errorToast(
+    'Layout could not be saved',
+    messages.length ? messages.join('\n') : 'Please reload the page or try again.'
+  )
+}
+
+const saveLayout = () => {
+  isSubmitting.value = true
+
+  const submitForm = useForm({
+    stageBlocks: form.stageBlocks.map(toStagePayload),
+    markerBlocks: form.markerBlocks.map(toMarkerPayload),
+    blocks: form.blocks.map(toBlockPayload)
+  })
+
+  submitForm.put(route('admin.rooms.layout.update', props.room.id), {
+    onFinish: () => { isSubmitting.value = false },
+    onSuccess: applyBlockIdMap,
+    onError: showSaveError
+  })
+}
+
+const newBlockNameInput = ref<HTMLInputElement | null>(null)
 
 const openNewBlockDialog = () => {
   showNewBlockDialog.value = true
@@ -420,20 +425,13 @@ const createNewBlock = () => {
     position_x: x,
     position_y: y,
     rotation: 0,
-    rowCount: 10,
-    defaultSeatsPerRow: DEFAULT_SEAT_COUNT,
-    rows: Array.from({ length: 10 }, (_, i) => ({
-      rowNumber: i + 1,
-      seatCount: DEFAULT_SEAT_COUNT,
-      isCustom: false,
-      alignment: 'center'
-    }))
+    rows: rowsFromBlock(null)
   })
 
   closeNewBlockDialog()
 }
 
-const addRow = (block) => {
+const addRow = (block: FormBlock) => {
   const newRowNumber = block.rows.length + 1
   block.rows.push({
     rowNumber: newRowNumber,
@@ -443,13 +441,13 @@ const addRow = (block) => {
   })
 }
 
-const removeRow = (block) => {
+const removeRow = (block: FormBlock) => {
   if (block.rows.length > 1) {
     block.rows.pop()
   }
 }
 
-const removeSpecificRow = (block, rowNumber) => {
+const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
   if (block.rows.length > 1) {
     const index = block.rows.findIndex(row => row.rowNumber === rowNumber)
     if (index !== -1) {
@@ -526,7 +524,7 @@ const removeSpecificRow = (block, rowNumber) => {
                 </div>
 
                 <div class="text-xs text-gray-500 mt-2">
-                  <span v-if="getBlockPlacementStatus(stageBlock)" class="text-green-600">• Placed ({{ stageBlock.position_y }}, {{ stageBlock.position_x }})</span>
+                  <span v-if="isPlaced(stageBlock)" class="text-green-600">• Placed ({{ stageBlock.position_y }}, {{ stageBlock.position_x }})</span>
                   <span v-else class="text-orange-600">• Not placed</span>
                 </div>
               </div>
@@ -584,7 +582,7 @@ const removeSpecificRow = (block, rowNumber) => {
                   <select
                     :value="marker.orientation"
                     @click.stop
-                    @change="setEntranceOrientation(marker, $event.target.value)"
+                    @change="setEntranceOrientation(marker, ($event.target as HTMLSelectElement).value as Orientation)"
                     class="text-xs h-7 border border-gray-300 rounded px-2 flex-1"
                   >
                     <option value="row">Full row (horizontal)</option>
@@ -659,7 +657,7 @@ const removeSpecificRow = (block, rowNumber) => {
                     />
                     <div class="text-xs text-gray-500 mt-1">
                       {{ getTotalSeats(block) }} seats • {{ block.rows.length }} rows
-                      <span v-if="getBlockPlacementStatus(block)" class="text-green-600">• Placed ({{ block.position_y }}, {{ block.position_x }})</span>
+                      <span v-if="isPlaced(block)" class="text-green-600">• Placed ({{ block.position_y }}, {{ block.position_x }})</span>
                       <span v-else class="text-orange-600">• Not placed</span>
                     </div>
                   </div>

--- a/resources/js/Pages/Booking/CreateBooking.vue
+++ b/resources/js/Pages/Booking/CreateBooking.vue
@@ -16,6 +16,7 @@ const props = defineProps({
     room: Object,
     blocks: Array,
     stageBlocks: Array,
+    markerBlocks: { type: Array, default: () => [] },
     bookedSeats: Array,
     selectedSeats: Array,
     maxSeatsPerUser: Number,
@@ -196,6 +197,7 @@ function goBack() {
                   :room="room"
                   :blocks="blocks"
                   :stage-blocks="stageBlocks"
+                  :marker-blocks="markerBlocks"
                   :selected-seats="selectedSeats"
                   :booked-seats="bookedSeats"
                   @seats-changed="handleSeatsChanged"

--- a/resources/js/types/layout.ts
+++ b/resources/js/types/layout.ts
@@ -74,14 +74,14 @@ export interface FormBlock {
 }
 
 export interface FormStageBlock {
-  id: BlockId | null
+  id: BlockId
   name: string
   position_x: number
   position_y: number
 }
 
 export interface FormMarkerBlock {
-  id: BlockId | null
+  id: BlockId
   type: MarkerType
   name: string
   position_x: number

--- a/resources/js/types/layout.ts
+++ b/resources/js/types/layout.ts
@@ -1,0 +1,91 @@
+export type Rotation = 0 | 90 | 180 | 270
+export type Orientation = 'row' | 'column'
+export type MarkerType = 'entrance' | 'comment'
+export type BlockId = number | string
+export type Alignment = 'left' | 'center' | 'right'
+
+export interface Seat {
+  id: number
+  label: string
+  name: string
+}
+
+export interface Row {
+  id: number
+  name: string
+  alignment?: Alignment
+  seats: Seat[]
+}
+
+export interface LayoutBlock {
+  id: BlockId
+  name: string
+  rotation?: number
+  position_x: number
+  position_y: number
+  rows?: Row[]
+}
+
+export interface PropRow {
+  seats_count?: number
+  custom_seat_count?: number | null
+  alignment?: string
+}
+
+export interface PropBlock {
+  id: BlockId
+  name: string
+  position_x: number
+  position_y: number
+  rotation?: number
+  rows?: PropRow[]
+}
+
+export interface PropStageBlock {
+  id: BlockId
+  name: string
+  position_x: number
+  position_y: number
+}
+
+export interface PropMarkerBlock {
+  id: BlockId
+  type: MarkerType
+  name: string
+  position_x: number
+  position_y: number
+  rotation?: number
+}
+
+export interface FormRow {
+  rowNumber: number
+  seatCount: number
+  isCustom: boolean
+  alignment: string
+}
+
+export interface FormBlock {
+  id: BlockId
+  name: string
+  position_x: number
+  position_y: number
+  rotation: number
+  rows: FormRow[]
+}
+
+export interface FormStageBlock {
+  id: BlockId | null
+  name: string
+  position_x: number
+  position_y: number
+}
+
+export interface FormMarkerBlock {
+  id: BlockId | null
+  type: MarkerType
+  name: string
+  position_x: number
+  position_y: number
+  orientation?: Orientation
+  rotation?: number
+}

--- a/tests/Feature/Admin/RoomLayoutControllerTest.php
+++ b/tests/Feature/Admin/RoomLayoutControllerTest.php
@@ -646,14 +646,13 @@ class RoomLayoutControllerTest extends TestCase
         Block::factory()->entrance()->create(['room_id' => $this->room->id, 'name' => 'Main Door', 'order' => 0]);
         Block::factory()->comment()->create(['room_id' => $this->room->id, 'name' => 'Pillar', 'order' => 1]);
 
-        $this->get(route('admin.rooms.layout', $this->room->id))
-            ->assertOk()
-            ->assertInertia(fn ($page) => $page
-                ->component('Admin/RoomLayout/Edit')
-                ->has('markerBlocks', 2)
-                ->where('markerBlocks.0.name', 'Main Door')
-                ->where('markerBlocks.1.name', 'Pillar')
-            );
+        $response = $this->get(route('admin.rooms.layout', $this->room->id));
+        $response->assertOk();
+
+        $props = $response->getOriginalContent()->getData()['page']['props'];
+        $this->assertCount(2, $props['markerBlocks']);
+        $this->assertEquals('Main Door', $props['markerBlocks'][0]['name']);
+        $this->assertEquals('Pillar', $props['markerBlocks'][1]['name']);
     }
 
     /** @test */
@@ -700,6 +699,119 @@ class RoomLayoutControllerTest extends TestCase
             $query->where('block_id', $block->id);
         })->count();
         $this->assertEquals(5, $newSeats);
+    }
+
+    /** @test */
+    public function omitting_stage_blocks_preserves_existing_stage_blocks()
+    {
+        $this->actingAs($this->admin);
+
+        $stage = Block::factory()->stage()->create(['room_id' => $this->room->id]);
+        $seating = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+
+        $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'blocks' => [
+                ['id' => $seating->id, 'name' => $seating->name, 'position_x' => $seating->position_x, 'position_y' => $seating->position_y, 'rotation' => $seating->rotation],
+            ],
+        ])->assertSessionHas('success');
+
+        $this->assertDatabaseHas('blocks', ['id' => $stage->id]);
+    }
+
+    /** @test */
+    public function omitting_marker_blocks_preserves_existing_marker_blocks()
+    {
+        $this->actingAs($this->admin);
+
+        $entrance = Block::factory()->entrance()->create(['room_id' => $this->room->id]);
+        $seating = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+
+        $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'blocks' => [
+                ['id' => $seating->id, 'name' => $seating->name, 'position_x' => $seating->position_x, 'position_y' => $seating->position_y, 'rotation' => $seating->rotation],
+            ],
+        ])->assertSessionHas('success');
+
+        $this->assertDatabaseHas('blocks', ['id' => $entrance->id]);
+    }
+
+    /** @test */
+    public function layout_update_rejects_comment_marker_with_negative_x()
+    {
+        $this->actingAs($this->admin);
+        $seating = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+
+        $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'markerBlocks' => [
+                ['id' => null, 'type' => 'comment', 'name' => 'Note', 'position_x' => -1, 'position_y' => 2, 'rotation' => 0],
+            ],
+            'blocks' => [
+                ['id' => $seating->id, 'name' => $seating->name, 'position_x' => 0, 'position_y' => 0, 'rotation' => 0],
+            ],
+        ])->assertSessionHasErrors('markerBlocks.0');
+    }
+
+    /** @test */
+    public function layout_update_rejects_entrance_marker_with_both_coordinates_negative()
+    {
+        $this->actingAs($this->admin);
+        $seating = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+
+        $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'markerBlocks' => [
+                ['id' => null, 'type' => 'entrance', 'name' => 'Door', 'position_x' => -1, 'position_y' => -1, 'rotation' => 0],
+            ],
+            'blocks' => [
+                ['id' => $seating->id, 'name' => $seating->name, 'position_x' => 0, 'position_y' => 0, 'rotation' => 0],
+            ],
+        ])->assertSessionHasErrors('markerBlocks.0');
+    }
+
+    /** @test */
+    public function layout_update_rejects_marker_coordinates_outside_grid()
+    {
+        $this->actingAs($this->admin);
+        $seating = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+
+        $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'markerBlocks' => [
+                ['id' => null, 'type' => 'comment', 'name' => 'Note', 'position_x' => 12, 'position_y' => 0, 'rotation' => 0],
+            ],
+            'blocks' => [
+                ['id' => $seating->id, 'name' => $seating->name, 'position_x' => 0, 'position_y' => 0, 'rotation' => 0],
+            ],
+        ])->assertSessionHasErrors('markerBlocks.0.position_x');
+
+        $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'markerBlocks' => [
+                ['id' => null, 'type' => 'comment', 'name' => 'Note', 'position_x' => 0, 'position_y' => 8, 'rotation' => 0],
+            ],
+            'blocks' => [
+                ['id' => $seating->id, 'name' => $seating->name, 'position_x' => 0, 'position_y' => 0, 'rotation' => 0],
+            ],
+        ])->assertSessionHasErrors('markerBlocks.0.position_y');
+    }
+
+    /** @test */
+    public function layout_update_accepts_temp_id_for_new_stage_and_marker_blocks()
+    {
+        $this->actingAs($this->admin);
+        $seating = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+
+        $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'stageBlocks' => [
+                ['id' => 'temp-1', 'name' => 'New Stage', 'position_x' => 0, 'position_y' => 0],
+            ],
+            'markerBlocks' => [
+                ['id' => 'temp-2', 'type' => 'entrance', 'name' => 'Door', 'position_x' => -1, 'position_y' => 1, 'rotation' => 0],
+            ],
+            'blocks' => [
+                ['id' => $seating->id, 'name' => $seating->name, 'position_x' => $seating->position_x, 'position_y' => $seating->position_y, 'rotation' => $seating->rotation],
+            ],
+        ])->assertSessionHas('success');
+
+        $this->assertDatabaseHas('blocks', ['room_id' => $this->room->id, 'type' => 'stage', 'name' => 'New Stage']);
+        $this->assertDatabaseHas('blocks', ['room_id' => $this->room->id, 'type' => 'entrance', 'name' => 'Door']);
     }
 
     /** @test */

--- a/tests/Feature/Admin/RoomLayoutControllerTest.php
+++ b/tests/Feature/Admin/RoomLayoutControllerTest.php
@@ -438,6 +438,225 @@ class RoomLayoutControllerTest extends TestCase
     }
 
     /** @test */
+    public function layout_update_reconciles_marker_blocks()
+    {
+        $this->actingAs($this->admin);
+
+        $keptEntrance = Block::factory()->create([
+            'room_id' => $this->room->id,
+            'type' => 'entrance',
+            'name' => 'Old Entrance',
+            'position_x' => -1,
+            'position_y' => 2,
+            'rotation' => 0,
+        ]);
+        $removedComment = Block::factory()->create([
+            'room_id' => $this->room->id,
+            'type' => 'comment',
+            'name' => 'Stale Note',
+        ]);
+
+        $seatingBlock = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+
+        $updateData = [
+            'markerBlocks' => [
+                [
+                    'id' => $keptEntrance->id,
+                    'type' => 'entrance',
+                    'name' => 'Main Entrance',
+                    'position_x' => -1,
+                    'position_y' => 3,
+                    'rotation' => 90,
+                ],
+                [
+                    'id' => null,
+                    'type' => 'comment',
+                    'name' => 'New Note',
+                    'position_x' => 4,
+                    'position_y' => 4,
+                    'rotation' => 0,
+                ],
+            ],
+            'blocks' => [
+                [
+                    'id' => $seatingBlock->id,
+                    'name' => $seatingBlock->name,
+                    'position_x' => $seatingBlock->position_x,
+                    'position_y' => $seatingBlock->position_y,
+                    'rotation' => $seatingBlock->rotation,
+                ],
+            ],
+        ];
+
+        $response = $this->put(route('admin.rooms.layout.update', $this->room->id), $updateData);
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success', 'Room layout updated successfully!');
+
+        // Existing marker updated in place
+        $this->assertDatabaseHas('blocks', [
+            'id' => $keptEntrance->id,
+            'type' => 'entrance',
+            'name' => 'Main Entrance',
+            'position_y' => 3,
+            'rotation' => 90,
+        ]);
+
+        // New marker created
+        $this->assertDatabaseHas('blocks', [
+            'room_id' => $this->room->id,
+            'type' => 'comment',
+            'name' => 'New Note',
+            'position_x' => 4,
+            'position_y' => 4,
+        ]);
+
+        // Marker absent from submission is deleted
+        $this->assertDatabaseMissing('blocks', ['id' => $removedComment->id]);
+    }
+
+    /** @test */
+    public function reconcile_updates_order_on_existing_blocks()
+    {
+        $this->actingAs($this->admin);
+
+        $stage1 = Block::factory()->stage()->create(['room_id' => $this->room->id, 'order' => 99]);
+        $stage2 = Block::factory()->stage()->create(['room_id' => $this->room->id, 'order' => 98]);
+        $seating = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+
+        // Submit with reversed order
+        $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'stageBlocks' => [
+                ['id' => $stage2->id, 'name' => $stage2->name, 'position_x' => $stage2->position_x, 'position_y' => $stage2->position_y],
+                ['id' => $stage1->id, 'name' => $stage1->name, 'position_x' => $stage1->position_x, 'position_y' => $stage1->position_y],
+            ],
+            'blocks' => [
+                ['id' => $seating->id, 'name' => $seating->name, 'position_x' => $seating->position_x, 'position_y' => $seating->position_y, 'rotation' => $seating->rotation],
+            ],
+        ])->assertSessionHas('success');
+
+        $this->assertDatabaseHas('blocks', ['id' => $stage2->id, 'order' => 0]);
+        $this->assertDatabaseHas('blocks', ['id' => $stage1->id, 'order' => 1]);
+    }
+
+    /** @test */
+    public function reconcile_deletes_all_blocks_when_empty_array_submitted()
+    {
+        $this->actingAs($this->admin);
+
+        $stage1 = Block::factory()->stage()->create(['room_id' => $this->room->id]);
+        $stage2 = Block::factory()->stage()->create(['room_id' => $this->room->id]);
+        $entrance = Block::factory()->entrance()->create(['room_id' => $this->room->id]);
+        $seating = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+
+        $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'stageBlocks' => [],
+            'markerBlocks' => [],
+            'blocks' => [
+                ['id' => $seating->id, 'name' => $seating->name, 'position_x' => $seating->position_x, 'position_y' => $seating->position_y, 'rotation' => $seating->rotation],
+            ],
+        ])->assertSessionHas('success');
+
+        $this->assertDatabaseMissing('blocks', ['id' => $stage1->id]);
+        $this->assertDatabaseMissing('blocks', ['id' => $stage2->id]);
+        $this->assertDatabaseMissing('blocks', ['id' => $entrance->id]);
+        $this->assertDatabaseHas('blocks', ['id' => $seating->id]);
+    }
+
+    /** @test */
+    public function reconcile_assigns_contiguous_order_to_new_and_existing_blocks()
+    {
+        $this->actingAs($this->admin);
+
+        $existing = Block::factory()->entrance()->create(['room_id' => $this->room->id, 'order' => 5]);
+        $seating = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+
+        $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'markerBlocks' => [
+                ['id' => null, 'type' => 'comment', 'name' => 'A', 'position_x' => 1, 'position_y' => 1, 'rotation' => 0],
+                ['id' => $existing->id, 'type' => 'entrance', 'name' => $existing->name, 'position_x' => $existing->position_x, 'position_y' => $existing->position_y, 'rotation' => 0],
+                ['id' => null, 'type' => 'comment', 'name' => 'B', 'position_x' => 2, 'position_y' => 2, 'rotation' => 0],
+            ],
+            'blocks' => [
+                ['id' => $seating->id, 'name' => $seating->name, 'position_x' => $seating->position_x, 'position_y' => $seating->position_y, 'rotation' => $seating->rotation],
+            ],
+        ])->assertSessionHas('success');
+
+        $this->assertDatabaseHas('blocks', ['name' => 'A', 'order' => 0]);
+        $this->assertDatabaseHas('blocks', ['id' => $existing->id, 'order' => 1]);
+        $this->assertDatabaseHas('blocks', ['name' => 'B', 'order' => 2]);
+    }
+
+    /** @test */
+    public function layout_update_validates_marker_block_type()
+    {
+        $this->actingAs($this->admin);
+        $seating = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+
+        $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'markerBlocks' => [
+                ['id' => null, 'type' => 'seating', 'name' => 'Bad', 'position_x' => 0, 'position_y' => 0, 'rotation' => 0],
+            ],
+            'blocks' => [
+                ['id' => $seating->id, 'name' => $seating->name, 'position_x' => 0, 'position_y' => 0, 'rotation' => 0],
+            ],
+        ])->assertSessionHasErrors('markerBlocks.0.type');
+    }
+
+    /** @test */
+    public function layout_update_validates_marker_block_rotation()
+    {
+        $this->actingAs($this->admin);
+        $seating = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+
+        $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'markerBlocks' => [
+                ['id' => null, 'type' => 'entrance', 'name' => 'Door', 'position_x' => -1, 'position_y' => 0, 'rotation' => 45],
+            ],
+            'blocks' => [
+                ['id' => $seating->id, 'name' => $seating->name, 'position_x' => 0, 'position_y' => 0, 'rotation' => 0],
+            ],
+        ])->assertSessionHasErrors('markerBlocks.0.rotation');
+    }
+
+    /** @test */
+    public function layout_update_rejects_marker_block_id_from_another_room()
+    {
+        $this->actingAs($this->admin);
+        $seating = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+        $other = Room::factory()->create();
+        $foreignMarker = Block::factory()->entrance()->create(['room_id' => $other->id]);
+
+        $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'markerBlocks' => [
+                ['id' => $foreignMarker->id, 'type' => 'entrance', 'name' => 'Door', 'position_x' => -1, 'position_y' => 0, 'rotation' => 0],
+            ],
+            'blocks' => [
+                ['id' => $seating->id, 'name' => $seating->name, 'position_x' => 0, 'position_y' => 0, 'rotation' => 0],
+            ],
+        ])->assertSessionHasErrors('markerBlocks.0.id');
+
+        $this->assertDatabaseHas('blocks', ['id' => $foreignMarker->id, 'room_id' => $other->id]);
+    }
+
+    /** @test */
+    public function layout_editor_includes_marker_blocks_in_page_props()
+    {
+        $this->actingAs($this->admin);
+        Block::factory()->entrance()->create(['room_id' => $this->room->id, 'name' => 'Main Door', 'order' => 0]);
+        Block::factory()->comment()->create(['room_id' => $this->room->id, 'name' => 'Pillar', 'order' => 1]);
+
+        $this->get(route('admin.rooms.layout', $this->room->id))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('Admin/RoomLayout/Edit')
+                ->has('markerBlocks', 2)
+                ->where('markerBlocks.0.name', 'Main Door')
+                ->where('markerBlocks.1.name', 'Pillar')
+            );
+    }
+
+    /** @test */
     public function row_recreation_deletes_old_structure()
     {
         $this->actingAs($this->admin);

--- a/tests/Feature/Admin/RoomLayoutControllerTest.php
+++ b/tests/Feature/Admin/RoomLayoutControllerTest.php
@@ -225,6 +225,42 @@ class RoomLayoutControllerTest extends TestCase
     }
 
     /** @test */
+    public function layout_update_returns_id_mapping_for_new_stage_and_marker_blocks()
+    {
+        $this->actingAs($this->admin);
+
+        $block = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+
+        $response = $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'stageBlocks' => [
+                ['id' => 'temp-1', 'name' => 'Stage 1', 'position_x' => 0, 'position_y' => 0],
+            ],
+            'markerBlocks' => [
+                ['id' => 'temp-2', 'type' => 'comment', 'name' => 'Note', 'position_x' => 1, 'position_y' => 1, 'rotation' => 0],
+            ],
+            'blocks' => [
+                [
+                    'id' => $block->id,
+                    'name' => $block->name,
+                    'position_x' => $block->position_x,
+                    'position_y' => $block->position_y,
+                    'rotation' => $block->rotation,
+                ],
+            ],
+        ]);
+
+        $response->assertSessionHas('success');
+
+        $stageId = Block::where('room_id', $this->room->id)->where('type', 'stage')->value('id');
+        $markerId = Block::where('room_id', $this->room->id)->where('type', 'comment')->value('id');
+
+        $response->assertSessionHas('blockIdMap', [
+            'temp-1' => $stageId,
+            'temp-2' => $markerId,
+        ]);
+    }
+
+    /** @test */
     public function layout_update_rejects_block_id_from_another_room()
     {
         $this->actingAs($this->admin);

--- a/tests/Unit/Models/BlockTest.php
+++ b/tests/Unit/Models/BlockTest.php
@@ -59,6 +59,44 @@ class BlockTest extends TestCase
     }
 
     /** @test */
+    public function marker_scope_filters_entrance_and_comment_blocks()
+    {
+        $room = Room::factory()->create();
+
+        $entrance = Block::factory()->entrance()->create(['room_id' => $room->id]);
+        $comment = Block::factory()->comment()->create(['room_id' => $room->id]);
+        $seating = Block::factory()->seating()->create(['room_id' => $room->id]);
+        $stage = Block::factory()->stage()->create(['room_id' => $room->id]);
+
+        $markers = Block::marker()->get();
+
+        $this->assertCount(2, $markers);
+        $this->assertTrue($markers->contains($entrance));
+        $this->assertTrue($markers->contains($comment));
+        $this->assertFalse($markers->contains($seating));
+        $this->assertFalse($markers->contains($stage));
+    }
+
+    /** @test */
+    public function room_marker_blocks_relation_returns_entrance_and_comment_blocks()
+    {
+        $room = Room::factory()->create();
+        $other = Room::factory()->create();
+
+        $entrance = Block::factory()->entrance()->create(['room_id' => $room->id, 'order' => 2]);
+        $comment = Block::factory()->comment()->create(['room_id' => $room->id, 'order' => 1]);
+        Block::factory()->seating()->create(['room_id' => $room->id]);
+        Block::factory()->entrance()->create(['room_id' => $other->id]);
+
+        $markers = $room->markerBlocks()->get();
+
+        $this->assertCount(2, $markers);
+        $this->assertTrue($markers->contains($entrance));
+        $this->assertTrue($markers->contains($comment));
+        $this->assertEquals($comment->id, $markers->first()->id); // ordered by 'order'
+    }
+
+    /** @test */
     public function block_has_rows_relationship_ordered_by_order()
     {
         $room = Room::factory()->create();


### PR DESCRIPTION
<img width="1117" height="671" alt="Screenshot 2026-07-19 at 01 09 12" src="https://github.com/user-attachments/assets/63b12592-b7e9-4f6f-b668-077d00e49bfb" />
<img width="997" height="253" alt="Screenshot 2026-07-19 at 01 11 33" src="https://github.com/user-attachments/assets/880f61da-0abb-4b59-bc21-6906d207cf9b" />
<img width="964" height="674" alt="Screenshot 2026-07-19 at 01 12 09" src="https://github.com/user-attachments/assets/a294e151-8505-469d-a821-75ba8da8980b" />

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added entrance and comment markers to room floor plans, event seat layouts, and booking views.
  * Updated seating-card PDF overviews to include entrance bands and labeled comment markers.
  * Enhanced the admin room layout editor to create, position, rotate, order, and remove markers.

* **Bug Fixes**
  * Improved marker rendering/grid merging with correct placement across stage, seating, and marker regions.
  * Strengthened marker validation and reconciliation, including correct ordering, preservation, and deletion behavior.

* **Tests**
  * Added feature and unit test coverage for marker reconciliation, validation, relationships, and ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->