### PR TITLE
Events did not show up with missing deadline

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -14,7 +14,10 @@ class EventController extends Controller
         // Events are shown even before their booking window opens, so staff/users
         // can see what's planned; the seat picker itself blocks booking until open.
         $events = Event::with('room:id,name')
-            ->where('reservation_ends_at', '>', now())
+            ->where(function ($query) {
+                $query->whereNull('reservation_ends_at')
+                    ->orWhere('reservation_ends_at', '>', now());
+            })
             ->where('starts_at', '>', now())
             ->select('id', 'room_id', 'name', 'starts_at', 'reservation_ends_at', 'booking_starts_at', 'tickets', 'max_tickets')
             ->orderBy('starts_at')

--- a/resources/js/Pages/Event/IndexEvent.vue
+++ b/resources/js/Pages/Event/IndexEvent.vue
@@ -123,7 +123,7 @@ function goBack() {
                       </div>
                       <div class="flex items-center">
                         <Calendar class="h-4 w-4 mr-2 flex-shrink-0" />
-                        <span class="text-xs lg:text-sm">Booking Deadline: {{ formatDateTime(event.reservation_ends_at) }}</span>
+                        <span class="text-xs lg:text-sm">Booking Deadline: {{ event.reservation_ends_at ? formatDateTime(event.reservation_ends_at) : 'No deadline' }}</span>
                       </div>
                     </div>
                   </div>

--- a/tests/Feature/BookingControllerTest.php
+++ b/tests/Feature/BookingControllerTest.php
@@ -479,6 +479,69 @@ class BookingControllerTest extends TestCase
     }
 
     /** @test */
+    public function events_index_includes_events_with_no_reservation_deadline()
+    {
+        $noDeadlineEvent = Event::factory()->create([
+            'room_id' => $this->room->id,
+            'starts_at' => Carbon::now()->addDays(7),
+            'reservation_ends_at' => null,
+            'max_tickets' => 100,
+            'booking_starts_at' => Carbon::now()->subMinute(),
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->get(route('events.index'));
+
+        $response->assertOk();
+        $events = $response->getOriginalContent()->getData()['page']['props']['events'];
+        $eventIds = collect($events)->pluck('id');
+
+        $this->assertTrue($eventIds->contains($noDeadlineEvent->id));
+    }
+
+    /** @test */
+    public function events_index_excludes_events_whose_deadline_has_passed()
+    {
+        $closedEvent = Event::factory()->create([
+            'room_id' => $this->room->id,
+            'starts_at' => Carbon::now()->addDays(7),
+            'reservation_ends_at' => Carbon::now()->subMinute(),
+            'max_tickets' => 100,
+            'booking_starts_at' => Carbon::now()->subDay(),
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->get(route('events.index'));
+
+        $response->assertOk();
+        $events = $response->getOriginalContent()->getData()['page']['props']['events'];
+        $eventIds = collect($events)->pluck('id');
+
+        $this->assertFalse($eventIds->contains($closedEvent->id));
+    }
+
+    /** @test */
+    public function events_index_excludes_events_that_have_already_started()
+    {
+        $startedEvent = Event::factory()->create([
+            'room_id' => $this->room->id,
+            'starts_at' => Carbon::now()->subMinute(),
+            'reservation_ends_at' => null,
+            'max_tickets' => 100,
+            'booking_starts_at' => Carbon::now()->subDay(),
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->get(route('events.index'));
+
+        $response->assertOk();
+        $events = $response->getOriginalContent()->getData()['page']['props']['events'];
+        $eventIds = collect($events)->pluck('id');
+
+        $this->assertFalse($eventIds->contains($startedEvent->id));
+    }
+
+    /** @test */
     public function user_cannot_book_when_no_tickets_left()
     {
         $this->event->update(['max_tickets' => 1]);


### PR DESCRIPTION
Also added more event index tests that checks all our filtering possibilities

Fixes #49 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Events without a booking deadline now appear in the event listing.
  * Event cards display “No deadline” when no booking deadline is set.

* **Bug Fixes**
  * Events with expired booking deadlines or that have already started are excluded from listings.

* **Tests**
  * Added coverage for event deadline and start-time filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->