### PR TITLE
Add colspan and rowspan to blocks

### DIFF
--- a/app/Booking/RoomLayoutLoader.php
+++ b/app/Booking/RoomLayoutLoader.php
@@ -30,7 +30,7 @@ class RoomLayoutLoader
     public function blocks(Room $room): Collection
     {
         return $room->blocks()
-            ->select('id', 'room_id', 'name', 'position_x', 'position_y', 'rotation', 'order')
+            ->select('id', 'room_id', 'name', 'position_x', 'position_y', 'rotation', 'colspan', 'rowspan', 'order')
             ->with(['rows' => function ($query) {
                 $query->select('id', 'block_id', 'name', 'order', 'alignment')
                     ->orderBy('order');
@@ -46,7 +46,7 @@ class RoomLayoutLoader
     public function stageBlocks(Room $room): Collection
     {
         return $room->stageBlocks()
-            ->select('id', 'room_id', 'name', 'position_x', 'position_y', 'order')
+            ->select('id', 'room_id', 'name', 'position_x', 'position_y', 'colspan', 'rowspan', 'order')
             ->orderBy('order')
             ->get();
     }

--- a/app/Http/Controllers/Admin/EventAdminController.php
+++ b/app/Http/Controllers/Admin/EventAdminController.php
@@ -118,7 +118,7 @@ class EventAdminController extends Controller
         [$room, $blocks, $stageBlocks, $bookedSeats] = $layout->load($event);
 
         $markerBlocks = $room->markerBlocks()
-            ->select('id', 'room_id', 'name', 'type', 'position_x', 'position_y', 'rotation', 'order')
+            ->select('id', 'room_id', 'name', 'type', 'position_x', 'position_y', 'rotation', 'colspan', 'rowspan', 'order')
             ->get();
 
         // Get seat to booking mapping for seat clicks

--- a/app/Http/Controllers/Admin/RoomLayoutController.php
+++ b/app/Http/Controllers/Admin/RoomLayoutController.php
@@ -84,6 +84,20 @@ class RoomLayoutController extends Controller
             }
         };
 
+        $spanFits = function (string $_attribute, $value, $fail) {
+            $x = isset($value['position_x']) ? (int) $value['position_x'] : null;
+            $y = isset($value['position_y']) ? (int) $value['position_y'] : null;
+            $colspan = isset($value['colspan']) ? (int) $value['colspan'] : 1;
+            $rowspan = isset($value['rowspan']) ? (int) $value['rowspan'] : 1;
+
+            if ($x !== null && $x !== -1 && $x + $colspan > 12) {
+                $fail('The block extends past the right edge of the grid.');
+            }
+            if ($y !== null && $y !== -1 && $y + $rowspan > 8) {
+                $fail('The block extends past the bottom edge of the grid.');
+            }
+        };
+
         $request->validate([
             'stageBlocks' => 'sometimes|array',
             'stageBlocks.*.id' => ['nullable', $ownedId($room->stageBlocks(), 'The selected stage block id is invalid for this room.')],
@@ -92,6 +106,7 @@ class RoomLayoutController extends Controller
             'stageBlocks.*.position_y' => 'required|integer|min:-1|max:7',
             'stageBlocks.*.colspan' => 'nullable|integer|min:1|max:12',
             'stageBlocks.*.rowspan' => 'nullable|integer|min:1|max:8',
+            'stageBlocks.*' => [$spanFits],
             'markerBlocks' => 'sometimes|array',
             'markerBlocks.*.id' => ['nullable', $ownedId($room->markerBlocks(), 'The selected marker block id is invalid for this room.')],
             'markerBlocks.*.type' => 'required|string|in:entrance,comment',
@@ -102,6 +117,7 @@ class RoomLayoutController extends Controller
             'markerBlocks.*.colspan' => 'nullable|integer|min:1|max:12',
             'markerBlocks.*.rowspan' => 'nullable|integer|min:1|max:8',
             'markerBlocks.*' => [
+                $spanFits,
                 function (string $_attribute, $value, $fail) {
                     $type = $value['type'] ?? null;
                     $x = isset($value['position_x']) ? (int) $value['position_x'] : null;
@@ -122,6 +138,7 @@ class RoomLayoutController extends Controller
             'blocks.*.rotation' => 'required|integer|in:0,90,180,270',
             'blocks.*.colspan' => 'nullable|integer|min:1|max:12',
             'blocks.*.rowspan' => 'nullable|integer|min:1|max:8',
+            'blocks.*' => [$spanFits],
             'blocks.*.rowsData' => 'nullable|array',
             'blocks.*.rowsData.*.rowNumber' => 'integer|min:1|max:50',
             'blocks.*.rowsData.*.seatCount' => 'integer|min:1|max:100',

--- a/app/Http/Controllers/Admin/RoomLayoutController.php
+++ b/app/Http/Controllers/Admin/RoomLayoutController.php
@@ -7,6 +7,7 @@ use App\Models\Booking;
 use App\Models\Room;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 
 class RoomLayoutController extends Controller
@@ -146,6 +147,8 @@ class RoomLayoutController extends Controller
             'blocks.*.rowsData.*.alignment' => 'nullable|string|in:left,center,right',
         ]);
 
+        $this->validateNoOverlaps($request);
+
         $blockIdMap = [];
 
         DB::transaction(function () use ($request, $room, &$blockIdMap) {
@@ -248,6 +251,53 @@ class RoomLayoutController extends Controller
         return back()
             ->with('success', 'Room layout updated successfully!')
             ->with('blockIdMap', $blockIdMap);
+    }
+
+    // Checks placed footprints (stage/marker/seating blocks) for overlaps after field validation has
+    // passed. Items with an unplaced axis (position_x or position_y === -1) are skipped, mirroring the
+    // $spanFits bounds check above: unplaced blocks and axis-band entrance markers have no footprint
+    // to compare here.
+    private function validateNoOverlaps(Request $request): void
+    {
+        $rects = [];
+
+        foreach (['stageBlocks', 'markerBlocks', 'blocks'] as $collection) {
+            foreach ($request->input($collection, []) as $index => $item) {
+                $x = isset($item['position_x']) ? (int) $item['position_x'] : -1;
+                $y = isset($item['position_y']) ? (int) $item['position_y'] : -1;
+                if ($x === -1 || $y === -1) {
+                    continue;
+                }
+
+                $colspan = isset($item['colspan']) ? (int) $item['colspan'] : 1;
+                $rowspan = isset($item['rowspan']) ? (int) $item['rowspan'] : 1;
+
+                $rects[] = [
+                    'attribute' => "{$collection}.{$index}.position_x",
+                    'x1' => $x,
+                    'y1' => $y,
+                    'x2' => $x + $colspan - 1,
+                    'y2' => $y + $rowspan - 1,
+                ];
+            }
+        }
+
+        $errors = [];
+        for ($i = 0; $i < count($rects); $i++) {
+            for ($j = $i + 1; $j < count($rects); $j++) {
+                $a = $rects[$i];
+                $b = $rects[$j];
+                $overlaps = $a['x1'] <= $b['x2'] && $a['x2'] >= $b['x1'] && $a['y1'] <= $b['y2'] && $a['y2'] >= $b['y1'];
+                if ($overlaps) {
+                    $errors[$a['attribute']] = 'This block overlaps another block.';
+                    $errors[$b['attribute']] = 'This block overlaps another block.';
+                }
+            }
+        }
+
+        if ($errors !== []) {
+            throw ValidationException::withMessages($errors);
+        }
     }
 
     public function createBlock(Request $request, Room $room)

--- a/app/Http/Controllers/Admin/RoomLayoutController.php
+++ b/app/Http/Controllers/Admin/RoomLayoutController.php
@@ -90,6 +90,8 @@ class RoomLayoutController extends Controller
             'stageBlocks.*.name' => 'required|string|max:255',
             'stageBlocks.*.position_x' => 'required|integer|min:-1|max:11',
             'stageBlocks.*.position_y' => 'required|integer|min:-1|max:7',
+            'stageBlocks.*.colspan' => 'nullable|integer|min:1|max:12',
+            'stageBlocks.*.rowspan' => 'nullable|integer|min:1|max:8',
             'markerBlocks' => 'sometimes|array',
             'markerBlocks.*.id' => ['nullable', $ownedId($room->markerBlocks(), 'The selected marker block id is invalid for this room.')],
             'markerBlocks.*.type' => 'required|string|in:entrance,comment',
@@ -97,6 +99,8 @@ class RoomLayoutController extends Controller
             'markerBlocks.*.position_x' => 'required|integer|min:-1|max:11',
             'markerBlocks.*.position_y' => 'required|integer|min:-1|max:7',
             'markerBlocks.*.rotation' => 'nullable|integer|in:0,90,180,270',
+            'markerBlocks.*.colspan' => 'nullable|integer|min:1|max:12',
+            'markerBlocks.*.rowspan' => 'nullable|integer|min:1|max:8',
             'markerBlocks.*' => [
                 function (string $_attribute, $value, $fail) {
                     $type = $value['type'] ?? null;
@@ -116,6 +120,8 @@ class RoomLayoutController extends Controller
             'blocks.*.position_x' => 'required|integer|min:-1|max:11',
             'blocks.*.position_y' => 'required|integer|min:-1|max:7',
             'blocks.*.rotation' => 'required|integer|in:0,90,180,270',
+            'blocks.*.colspan' => 'nullable|integer|min:1|max:12',
+            'blocks.*.rowspan' => 'nullable|integer|min:1|max:8',
             'blocks.*.rowsData' => 'nullable|array',
             'blocks.*.rowsData.*.rowNumber' => 'integer|min:1|max:50',
             'blocks.*.rowsData.*.seatCount' => 'integer|min:1|max:100',
@@ -134,6 +140,8 @@ class RoomLayoutController extends Controller
                         'position_x' => $data['position_x'],
                         'position_y' => $data['position_y'],
                         'rotation' => 0,
+                        'colspan' => $data['colspan'] ?? 1,
+                        'rowspan' => $data['rowspan'] ?? 1,
                         'order' => $index,
                     ];
                 }, $blockIdMap);
@@ -147,6 +155,8 @@ class RoomLayoutController extends Controller
                         'position_x' => $data['position_x'],
                         'position_y' => $data['position_y'],
                         'rotation' => $data['rotation'] ?? 0,
+                        'colspan' => $data['colspan'] ?? 1,
+                        'rowspan' => $data['rowspan'] ?? 1,
                         'order' => $index,
                     ];
                 }, $blockIdMap);
@@ -165,6 +175,8 @@ class RoomLayoutController extends Controller
                         'position_x' => $blockData['position_x'],
                         'position_y' => $blockData['position_y'],
                         'rotation' => $blockData['rotation'],
+                        'colspan' => $blockData['colspan'] ?? 1,
+                        'rowspan' => $blockData['rowspan'] ?? 1,
                         'order' => $nextBlockOrder++,
                     ]);
                     $blockIdMap[$blockData['id']] = $block->id;
@@ -179,6 +191,8 @@ class RoomLayoutController extends Controller
                         'position_x' => $blockData['position_x'],
                         'position_y' => $blockData['position_y'],
                         'rotation' => $blockData['rotation'],
+                        'colspan' => $blockData['colspan'] ?? 1,
+                        'rowspan' => $blockData['rowspan'] ?? 1,
                     ]);
 
                     // If rowsData is provided, update the block structure

--- a/app/Http/Controllers/Admin/SeatingCardsController.php
+++ b/app/Http/Controllers/Admin/SeatingCardsController.php
@@ -68,7 +68,7 @@ class SeatingCardsController extends Controller
 
             $room = $event->room;
             $masterBlocks = $room->blocks()
-                ->select('id', 'room_id', 'name', 'position_x', 'position_y', 'rotation')
+                ->select('id', 'room_id', 'name', 'position_x', 'position_y', 'rotation', 'colspan', 'rowspan')
                 ->with(['rows' => function ($query) {
                     $query->select('id', 'block_id', 'order', 'alignment')
                         ->orderBy('order')
@@ -76,10 +76,10 @@ class SeatingCardsController extends Controller
                 }])
                 ->get();
             $masterStageBlocks = $room->stageBlocks()
-                ->select('id', 'room_id', 'name', 'position_x', 'position_y')
+                ->select('id', 'room_id', 'name', 'position_x', 'position_y', 'colspan', 'rowspan')
                 ->get();
             $masterMarkerBlocks = $room->markerBlocks()
-                ->select('id', 'room_id', 'name', 'type', 'position_x', 'position_y', 'rotation')
+                ->select('id', 'room_id', 'name', 'type', 'position_x', 'position_y', 'rotation', 'colspan', 'rowspan')
                 ->get();
 
             // mPDF configuration with custom Zhurzh font

--- a/app/Http/Controllers/BookingController.php
+++ b/app/Http/Controllers/BookingController.php
@@ -83,7 +83,7 @@ class BookingController extends Controller
             : [];
 
         $markerBlocks = $event->room->markerBlocks()
-            ->select('id', 'room_id', 'name', 'type', 'position_x', 'position_y', 'rotation', 'order')
+            ->select('id', 'room_id', 'name', 'type', 'position_x', 'position_y', 'rotation', 'colspan', 'rowspan', 'order')
             ->get();
 
         return Inertia::render('Booking/CreateBooking', [
@@ -263,7 +263,7 @@ class BookingController extends Controller
             ->find($booking->id);
 
         $markerBlocks = $event->room->markerBlocks()
-            ->select('id', 'room_id', 'name', 'type', 'position_x', 'position_y', 'rotation', 'order')
+            ->select('id', 'room_id', 'name', 'type', 'position_x', 'position_y', 'rotation', 'colspan', 'rowspan', 'order')
             ->get();
 
         // Get user's booked seat IDs for highlighting

--- a/app/Models/Block.php
+++ b/app/Models/Block.php
@@ -20,6 +20,8 @@ class Block extends Model
         'position_x',
         'position_y',
         'rotation',
+        'colspan',
+        'rowspan',
         'order',
     ];
 
@@ -27,6 +29,8 @@ class Block extends Model
         'rotation' => 'integer',
         'position_x' => 'integer',
         'position_y' => 'integer',
+        'colspan' => 'integer',
+        'rowspan' => 'integer',
         'order' => 'integer',
     ];
 

--- a/app/Services/Svg/MasterCardSvgGenerator.php
+++ b/app/Services/Svg/MasterCardSvgGenerator.php
@@ -74,7 +74,7 @@ class MasterCardSvgGenerator
             $svg .= match ($c['type']) {
                 'stage' => $this->stageCell($c, $bx, $by, $cw, $ch, $mpdf),
                 'comment' => $this->commentCell($c, $bx, $by, $cw, $ch, $mpdf),
-                default => $this->seatingCell($c, $bx, $by, $bookedSeatIds, $mpdf),
+                default => $this->seatingCell($c, $bx, $by, $cw, $ch, $bookedSeatIds, $mpdf),
             };
         }
 
@@ -282,12 +282,12 @@ class MasterCardSvgGenerator
         return $svg;
     }
 
-    private function seatingCell(array $c, float $bx, float $by, array $bookedSeatIds, Mpdf $mpdf): string
+    private function seatingCell(array $c, float $bx, float $by, float $cw, float $ch, array $bookedSeatIds, Mpdf $mpdf): string
     {
-        $cxMid = $bx + $c['w'] / 2;
+        $cxMid = $bx + $cw / 2;
 
-        return $this->svg->rect($bx, $by, $c['w'], $c['h'], 'none', 3, 10)
-            .$this->svg->centeredLabelX($mpdf, $c['block']->name, SvgUtilities::SIZE_BLOCK_LABEL, '#000000', $cxMid, $by + 22, $c['w'] - 12)
+        return $this->svg->rect($bx, $by, $cw, $ch, 'none', 3, 10)
+            .$this->svg->centeredLabelX($mpdf, $c['block']->name, SvgUtilities::SIZE_BLOCK_LABEL, '#000000', $cxMid, $by + 22, $cw - 12)
             .$this->seatDots($c, $cxMid, $by, $bookedSeatIds);
     }
 

--- a/app/Services/Svg/MasterCardSvgGenerator.php
+++ b/app/Services/Svg/MasterCardSvgGenerator.php
@@ -92,15 +92,17 @@ class MasterCardSvgGenerator
     {
         $placed = fn ($b) => $b->position_x !== null && $b->position_y !== null && $b->position_x >= 0 && $b->position_y >= 0;
 
+        $span = fn ($b, string $key) => max((int) ($b->{$key} ?? 1), 1);
+
         $cells = [];
         foreach ($stageBlocks as $sb) {
             if ($placed($sb)) {
-                $cells[] = ['x' => $sb->position_x, 'y' => $sb->position_y, 'type' => 'stage', 'block' => $sb, 'w' => self::STAGE_SIZE, 'h' => self::STAGE_SIZE, 'colSpan' => 1, 'rowSpan' => 1];
+                $cells[] = ['x' => $sb->position_x, 'y' => $sb->position_y, 'type' => 'stage', 'block' => $sb, 'w' => self::STAGE_SIZE, 'h' => self::STAGE_SIZE, 'colSpan' => $span($sb, 'colspan'), 'rowSpan' => $span($sb, 'rowspan')];
             }
         }
         foreach ($markerBlocks as $mb) {
             if ($mb->type === 'comment' && $placed($mb)) {
-                $cells[] = ['x' => $mb->position_x, 'y' => $mb->position_y, 'type' => 'comment', 'block' => $mb, 'w' => self::STAGE_SIZE, 'h' => self::STAGE_SIZE, 'colSpan' => 1, 'rowSpan' => 1];
+                $cells[] = ['x' => $mb->position_x, 'y' => $mb->position_y, 'type' => 'comment', 'block' => $mb, 'w' => self::STAGE_SIZE, 'h' => self::STAGE_SIZE, 'colSpan' => $span($mb, 'colspan'), 'rowSpan' => $span($mb, 'rowspan')];
             }
         }
         foreach ($blocks as $b) {
@@ -121,64 +123,11 @@ class MasterCardSvgGenerator
                 'gridCols' => $gridCols, 'gridRows' => $gridRows,
                 'w' => self::IN_PAD * 2 + $gridCols * self::PITCH,
                 'h' => self::HEADER + self::IN_PAD + $gridRows * self::PITCH,
-                'colSpan' => 1, 'rowSpan' => 1,
+                'colSpan' => $span($b, 'colspan'), 'rowSpan' => $span($b, 'rowspan'),
             ];
         }
 
-        $this->mergeAdjacentCells($cells, 'stage');
-        $this->mergeAdjacentCells($cells, 'comment');
-
         return $cells;
-    }
-
-    /**
-     * @param  array<int,array<string,mixed>>  $cells
-     */
-    private function mergeAdjacentCells(array &$cells, string $type): void
-    {
-        $grid = [];
-        foreach ($cells as $i => $c) {
-            if ($c['type'] === $type) {
-                $grid[$c['y']][$c['x']] = $i;
-            }
-        }
-        ksort($grid);
-
-        $covered = [];
-        $match = fn (int $y, int $x, string $name) => isset($grid[$y][$x]) && ! isset($covered[$grid[$y][$x]]) && $cells[$grid[$y][$x]]['block']->name === $name;
-
-        foreach ($grid as $y => $row) {
-            ksort($row);
-            foreach ($row as $x => $i) {
-                if (isset($covered[$i])) {
-                    continue;
-                }
-
-                $name = $cells[$i]['block']->name;
-                $colSpan = 1;
-                while ($match($y, $x + $colSpan, $name)) {
-                    $colSpan++;
-                }
-
-                $rowSpan = 1;
-                while (! in_array(false, array_map(fn ($dc) => $match($y + $rowSpan, $x + $dc, $name), range(0, $colSpan - 1)))) {
-                    $rowSpan++;
-                }
-
-                $cells[$i]['colSpan'] = $colSpan;
-                $cells[$i]['rowSpan'] = $rowSpan;
-
-                for ($dr = 0; $dr < $rowSpan; $dr++) {
-                    for ($dc = 0; $dc < $colSpan; $dc++) {
-                        if ($dr || $dc) {
-                            $covered[$grid[$y + $dr][$x + $dc]] = true;
-                        }
-                    }
-                }
-            }
-        }
-
-        $cells = array_values(array_filter($cells, fn ($i) => ! isset($covered[$i]), ARRAY_FILTER_USE_KEY));
     }
 
     /**

--- a/app/Services/Svg/MasterCardSvgGenerator.php
+++ b/app/Services/Svg/MasterCardSvgGenerator.php
@@ -97,12 +97,16 @@ class MasterCardSvgGenerator
         $cells = [];
         foreach ($stageBlocks as $sb) {
             if ($placed($sb)) {
-                $cells[] = ['x' => $sb->position_x, 'y' => $sb->position_y, 'type' => 'stage', 'block' => $sb, 'w' => self::STAGE_SIZE, 'h' => self::STAGE_SIZE, 'colSpan' => $span($sb, 'colspan'), 'rowSpan' => $span($sb, 'rowspan')];
+                $colSpan = $span($sb, 'colspan');
+                $rowSpan = $span($sb, 'rowspan');
+                $cells[] = ['x' => $sb->position_x, 'y' => $sb->position_y, 'type' => 'stage', 'block' => $sb, 'w' => self::STAGE_SIZE * $colSpan, 'h' => self::STAGE_SIZE * $rowSpan, 'colSpan' => $colSpan, 'rowSpan' => $rowSpan];
             }
         }
         foreach ($markerBlocks as $mb) {
             if ($mb->type === 'comment' && $placed($mb)) {
-                $cells[] = ['x' => $mb->position_x, 'y' => $mb->position_y, 'type' => 'comment', 'block' => $mb, 'w' => self::STAGE_SIZE, 'h' => self::STAGE_SIZE, 'colSpan' => $span($mb, 'colspan'), 'rowSpan' => $span($mb, 'rowspan')];
+                $colSpan = $span($mb, 'colspan');
+                $rowSpan = $span($mb, 'rowspan');
+                $cells[] = ['x' => $mb->position_x, 'y' => $mb->position_y, 'type' => 'comment', 'block' => $mb, 'w' => self::STAGE_SIZE * $colSpan, 'h' => self::STAGE_SIZE * $rowSpan, 'colSpan' => $colSpan, 'rowSpan' => $rowSpan];
             }
         }
         foreach ($blocks as $b) {

--- a/database/migrations/2026_07_26_113314_add_colspan_and_rowspan_to_blocks_table.php
+++ b/database/migrations/2026_07_26_113314_add_colspan_and_rowspan_to_blocks_table.php
@@ -10,23 +10,42 @@ return new class extends Migration
     // Only merge the ones that were merged visually before this migration
     private const SPAN_TYPES = ['stage', 'comment'];
 
+    // If up() fails (e.g. mergeAdjacentBlocks() throws), this migration is NOT recorded as
+    // "Ran" - `php artisan migrate:rollback` then targets whatever migration IS the last
+    // recorded batch instead, i.e. a DIFFERENT, unrelated, already-successful migration, not
+    // this one. Do not reflexively run migrate:rollback after a failure here. The failed
+    // state is safe to leave as-is (the merge transaction rolled back, so colspan/rowspan
+    // just sit at their harmless default of 1 on every block); fix the data issue and re-run
+    // `php artisan migrate` - the Schema::hasColumn() guards below make that retry safe.
+
     public function up(): void
     {
-        Schema::table('blocks', function (Blueprint $table) {
-            $table->integer('colspan')->default(1)->after('rotation');
-            $table->integer('rowspan')->default(1)->after('colspan');
-        });
+        // Idempotent: MySQL auto-commits ALTER TABLE regardless of the transaction below, so
+        // if a previous attempt added these columns but then failed/rolled back partway
+        // through the merge (leaving this migration "Pending"), a retry must not re-add them.
+        if (! Schema::hasColumn('blocks', 'colspan')) {
+            Schema::table('blocks', function (Blueprint $table) {
+                $table->integer('colspan')->default(1)->after('rotation');
+                $table->integer('rowspan')->default(1)->after('colspan');
+            });
+        }
 
-        $this->mergeAdjacentBlocks();
+        // MySQL auto-commits the ALTER TABLE above regardless, but the merge below issues
+        // many UPDATE/DELETE statements across every room - wrap it so a failure partway
+        // through (e.g. one room's data trips an edge case) rolls back cleanly instead of
+        // leaving some rooms merged and others not.
+        DB::transaction(fn () => $this->mergeAdjacentBlocks());
     }
 
     public function down(): void
     {
-        $this->splitSpannedBlocks();
+        DB::transaction(fn () => $this->splitSpannedBlocks());
 
-        Schema::table('blocks', function (Blueprint $table) {
-            $table->dropColumn(['colspan', 'rowspan']);
-        });
+        if (Schema::hasColumn('blocks', 'colspan')) {
+            Schema::table('blocks', function (Blueprint $table) {
+                $table->dropColumn(['colspan', 'rowspan']);
+            });
+        }
     }
 
     private function mergeAdjacentBlocks(): void
@@ -55,6 +74,8 @@ return new class extends Migration
         }
 
         $consumed = [];
+        // Stage/comment blocks are always created with rotation 0 (RoomLayoutController forces
+        // it), so there's no rotation to compare here.
         $free = fn (int $x, int $y, $ref) => ! isset($consumed["{$x},{$y}"])
             && ($grid["{$x},{$y}"] ?? null)?->name === $ref->name;
 
@@ -96,6 +117,10 @@ return new class extends Migration
 
     private function splitSpannedBlocks(): void
     {
+        // Only ever reverse what mergeAdjacentBlocks() did (stage/comment). A seating block's
+        // colspan/rowspan is set through the room layout editor's resize feature, not by this
+        // migration - splitting it here would clone an empty seating block next to the real
+        // one, duplicating it without any of its actual rows/seats.
         $spanned = DB::table('blocks')
             ->whereIn('type', self::SPAN_TYPES)
             ->where(function ($query) {

--- a/database/migrations/2026_07_26_113314_add_colspan_and_rowspan_to_blocks_table.php
+++ b/database/migrations/2026_07_26_113314_add_colspan_and_rowspan_to_blocks_table.php
@@ -1,0 +1,133 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    // Only merge the ones that were merged visually before this migration
+    private const SPAN_TYPES = ['stage', 'comment'];
+
+    public function up(): void
+    {
+        Schema::table('blocks', function (Blueprint $table) {
+            $table->integer('colspan')->default(1)->after('rotation');
+            $table->integer('rowspan')->default(1)->after('colspan');
+        });
+
+        $this->mergeAdjacentBlocks();
+    }
+
+    public function down(): void
+    {
+        $this->splitSpannedBlocks();
+
+        Schema::table('blocks', function (Blueprint $table) {
+            $table->dropColumn(['colspan', 'rowspan']);
+        });
+    }
+
+    private function mergeAdjacentBlocks(): void
+    {
+        foreach ($this->roomIds() as $roomId) {
+            foreach (self::SPAN_TYPES as $type) {
+                $this->mergeRoomType($roomId, $type);
+            }
+        }
+    }
+
+    private function mergeRoomType(int $roomId, string $type): void
+    {
+        $blocks = DB::table('blocks')
+            ->where('room_id', $roomId)
+            ->where('type', $type)
+            ->where('position_x', '>=', 0)
+            ->where('position_y', '>=', 0)
+            ->get(['id', 'name', 'position_x', 'position_y']);
+
+        $grid = [];
+        foreach ($blocks as $block) {
+            $grid["{$block->position_x},{$block->position_y}"] = $block;
+        }
+
+        $consumed = [];
+        $free = fn (int $x, int $y, $ref) => ! isset($consumed["{$x},{$y}"])
+            && ($grid["{$x},{$y}"] ?? null)?->name === $ref->name;
+
+        foreach ($blocks as $block) {
+            $x = $block->position_x;
+            $y = $block->position_y;
+            if (isset($consumed["{$x},{$y}"])) {
+                continue;
+            }
+
+            $colspan = 1;
+            while ($free($x + $colspan, $y, $block)) {
+                $colspan++;
+            }
+
+            $rowspan = 1;
+            while (collect(range(0, $colspan - 1))->every(fn ($dc) => $free($x + $dc, $y + $rowspan, $block))) {
+                $rowspan++;
+            }
+
+            if ($colspan === 1 && $rowspan === 1) {
+                continue;
+            }
+
+            $coveredIds = [];
+            for ($dr = 0; $dr < $rowspan; $dr++) {
+                for ($dc = 0; $dc < $colspan; $dc++) {
+                    if ($dr || $dc) {
+                        $consumed[($x + $dc).','.($y + $dr)] = true;
+                        $coveredIds[] = $grid[($x + $dc).','.($y + $dr)]->id;
+                    }
+                }
+            }
+
+            DB::table('blocks')->where('id', $block->id)->update(compact('colspan', 'rowspan'));
+            DB::table('blocks')->whereIn('id', $coveredIds)->delete();
+        }
+    }
+
+    private function splitSpannedBlocks(): void
+    {
+        $spanned = DB::table('blocks')
+            ->whereIn('type', self::SPAN_TYPES)
+            ->where(function ($query) {
+                $query->where('colspan', '>', 1)->orWhere('rowspan', '>', 1);
+            })
+            ->get();
+
+        foreach ($spanned as $block) {
+            $clones = [];
+            for ($dr = 0; $dr < $block->rowspan; $dr++) {
+                for ($dc = 0; $dc < $block->colspan; $dc++) {
+                    if ($dr || $dc) {
+                        $clones[] = [
+                            'room_id' => $block->room_id,
+                            'name' => $block->name,
+                            'type' => $block->type,
+                            'position_x' => $block->position_x + $dc,
+                            'position_y' => $block->position_y + $dr,
+                            'rotation' => $block->rotation,
+                            'order' => $block->order,
+                        ];
+                    }
+                }
+            }
+
+            DB::table('blocks')->insert($clones);
+        }
+    }
+
+    /**
+     * @return array<int,int>
+     */
+    private function roomIds(): array
+    {
+        return DB::table('blocks')->distinct()->pluck('room_id')->all();
+    }
+};

--- a/database/migrations/2026_07_26_113314_add_colspan_and_rowspan_to_blocks_table.php
+++ b/database/migrations/2026_07_26_113314_add_colspan_and_rowspan_to_blocks_table.php
@@ -45,6 +45,8 @@ return new class extends Migration
             ->where('type', $type)
             ->where('position_x', '>=', 0)
             ->where('position_y', '>=', 0)
+            ->orderBy('position_y')
+            ->orderBy('position_x')
             ->get(['id', 'name', 'position_x', 'position_y']);
 
         $grid = [];

--- a/resources/js/Components/SeatLayout.vue
+++ b/resources/js/Components/SeatLayout.vue
@@ -256,10 +256,13 @@ watch(() => props.selectedSeats, (newSeats) => {
                     'entrance-layout-column': cell && cell.type === 'entrance' && cell.orientation === 'column'
                   }
                 ]"
+                :style="cell && (cell.type === 'stage' || cell.type === 'comment')
+                  ? { minWidth: `${(cell.colSpan ?? 1) * 200}px`, minHeight: `${(cell.rowSpan ?? 1) * 60}px` }
+                  : undefined"
               >
                 <div v-if="cell === null" class="empty-cell"></div>
 
-                <div v-else-if="cell.type === 'stage'" class="stage-text" :style="{ minWidth: `${(cell.colSpan ?? 1) * 200}px`, minHeight: `${(cell.rowSpan ?? 1) * 60}px` }">
+                <div v-else-if="cell.type === 'stage'" class="stage-text">
                   {{ cell.name || 'STAGE' }}
                 </div>
 
@@ -288,7 +291,7 @@ watch(() => props.selectedSeats, (newSeats) => {
                   <component :is="arrow(cell.rotation)" class="entrance-arrow" />
                 </div>
 
-                <div v-else-if="cell.type === 'comment'" class="comment-text" :style="{ minWidth: `${(cell.colSpan ?? 1) * 200}px`, minHeight: `${(cell.rowSpan ?? 1) * 60}px` }">
+                <div v-else-if="cell.type === 'comment'" class="comment-text">
                   {{ cell.name }}
                 </div>
               </td>
@@ -535,11 +538,11 @@ watch(() => props.selectedSeats, (newSeats) => {
 }
 
 .comment-text {
+  position: absolute;
+  inset: 8px;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 100%;
-  height: 100%;
   padding: 6px;
   background-color: #f3f4f6;
   border: 1px solid #d1d5db;

--- a/resources/js/Components/SeatLayout.vue
+++ b/resources/js/Components/SeatLayout.vue
@@ -250,6 +250,7 @@ watch(() => props.selectedSeats, (newSeats) => {
                   'layout-cell',
                   {
                     'stage-layout-cell': cell && cell.type === 'stage',
+                    'comment-layout-cell': cell && cell.type === 'comment',
                     'entrance-layout-cell': cell && cell.type === 'entrance',
                     'entrance-layout-row': cell && cell.type === 'entrance' && cell.orientation === 'row',
                     'entrance-layout-column': cell && cell.type === 'entrance' && cell.orientation === 'column'
@@ -287,7 +288,7 @@ watch(() => props.selectedSeats, (newSeats) => {
                   <component :is="arrow(cell.rotation)" class="entrance-arrow" />
                 </div>
 
-                <div v-else-if="cell.type === 'comment'" class="comment-text" :style="{ minWidth: `${(cell.colSpan ?? 1) * 60}px`, minHeight: `${(cell.rowSpan ?? 1) * 60}px` }">
+                <div v-else-if="cell.type === 'comment'" class="comment-text">
                   {{ cell.name }}
                 </div>
               </td>
@@ -400,6 +401,13 @@ watch(() => props.selectedSeats, (newSeats) => {
   cursor: not-allowed;
   user-select: none;
   min-width: 200px;
+}
+
+.comment-layout-cell {
+  position: relative;
+  padding: 8px;
+  min-width: 200px;
+  min-height: 60px;
 }
 
 .entrance-layout-cell {
@@ -527,12 +535,11 @@ watch(() => props.selectedSeats, (newSeats) => {
 }
 
 .comment-text {
+  position: absolute;
+  inset: 8px;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 100%;
-  height: 100%;
-  min-height: 60px;
   padding: 6px;
   background-color: #f3f4f6;
   border: 1px solid #d1d5db;
@@ -542,7 +549,8 @@ watch(() => props.selectedSeats, (newSeats) => {
   font-weight: 600;
   text-align: center;
   white-space: normal;
-  word-break: break-word;
+  overflow-wrap: normal;
+  word-break: normal;
   user-select: none;
 }
 </style>

--- a/resources/js/Components/SeatLayout.vue
+++ b/resources/js/Components/SeatLayout.vue
@@ -69,19 +69,11 @@ const layoutGrid = computed(() => {
   const inGrid = (col: number, row: number) => col >= 0 && col < cols && row >= 0 && row < rows
 
   props.stageBlocks?.forEach(stageBlock => {
-    const col = stageBlock.position_x - offsetX
-    const row = stageBlock.position_y - offsetY
-    if (stageBlock.position_x >= 0 && stageBlock.position_y >= 0 && inGrid(col, row)) {
-      grid[row][col] = { type: 'stage', name: stageBlock.name }
-    }
+    place(stageBlock, { type: 'stage', name: stageBlock.name })
   })
 
   props.blocks?.forEach(block => {
-    const col = block.position_x - offsetX
-    const row = block.position_y - offsetY
-    if (block.position_x >= 0 && block.position_y >= 0 && inGrid(col, row)) {
-      grid[row][col] = { type: 'block', ...block }
-    }
+    place(block, { type: 'block', ...block })
   })
 
   const bounds = blockBounds.value
@@ -90,11 +82,7 @@ const layoutGrid = computed(() => {
     const { position_x: x, position_y: y, name } = marker
 
     if (marker.type === 'comment') {
-      const col = x - offsetX
-      const row = y - offsetY
-      if (x >= 0 && y >= 0 && inGrid(col, row)) {
-        grid[row][col] = { type: 'comment', name }
-      }
+      place(marker, { type: 'comment', name })
       return
     }
 
@@ -107,44 +95,25 @@ const layoutGrid = computed(() => {
     }
   })
 
-  mergeAdjacentCells('stage')
-  mergeAdjacentCells('comment')
-
   return grid
 
-  function isCandidate(cell: GridCell | null | undefined, ref: GridCellNamed): cell is GridCellNamed {
-    return cell?.type === ref.type && (cell as GridCellNamed)?.name === ref.name
-  }
+  function place(
+    source: { position_x: number, position_y: number, colspan?: number, rowspan?: number },
+    cell: Exclude<GridCell, GridCellCovered>
+  ) {
+    const col = source.position_x - offsetX
+    const row = source.position_y - offsetY
+    if (source.position_x < 0 || source.position_y < 0 || !inGrid(col, row)) return
 
-  function rowMatchesSpan(r: number, c: number, colSpan: number, ref: GridCellNamed) {
-    for (let dc = 0; dc < colSpan; dc++) {
-      if (!isCandidate(grid[r]?.[c + dc], ref)) return false
-    }
-    return true
-  }
+    const colSpan = Math.max(1, source.colspan ?? 1)
+    const rowSpan = Math.max(1, source.rowspan ?? 1)
 
-  function mergeAdjacentCells(type: GridCellNamed['type']) {
-    for (let r = 0; r < rows; r++) {
-      for (let c = 0; c < cols; c++) {
-        const cell = grid[r][c]
-        if (cell?.type !== type) continue
-
-        const ref: GridCellNamed = { type, name: (cell as GridCellNamed).name }
-
-        let colSpan = 1
-        while (c + colSpan < cols && isCandidate(grid[r][c + colSpan], ref)) colSpan++
-
-        let rowSpan = 1
-        while (r + rowSpan < rows && rowMatchesSpan(r + rowSpan, c, colSpan, ref)) rowSpan++
-
-        for (let dr = 0; dr < rowSpan; dr++) {
-          for (let dc = 0; dc < colSpan; dc++) {
-            if (dr === 0 && dc === 0) continue
-            grid[r + dr][c + dc] = { type: 'covered' }
-          }
-        }
-
-        grid[r][c] = { ...ref, colSpan, rowSpan }
+    for (let dr = 0; dr < rowSpan; dr++) {
+      for (let dc = 0; dc < colSpan; dc++) {
+        if (!inGrid(col + dc, row + dr)) continue
+        grid[row + dr][col + dc] = (dr === 0 && dc === 0)
+          ? { ...cell, colSpan, rowSpan }
+          : { type: 'covered' }
       }
     }
   }
@@ -165,17 +134,17 @@ const layoutGrid = computed(() => {
 const blockBounds = computed(() => {
   let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity
 
-  const consider = (x: number, y: number) => {
+  const consider = (x: number, y: number, colspan = 1, rowspan = 1) => {
     if (x >= 0 && y >= 0) {
-      minX = Math.min(minX, x); maxX = Math.max(maxX, x)
-      minY = Math.min(minY, y); maxY = Math.max(maxY, y)
+      minX = Math.min(minX, x); maxX = Math.max(maxX, x + colspan - 1)
+      minY = Math.min(minY, y); maxY = Math.max(maxY, y + rowspan - 1)
     }
   }
 
-  props.blocks?.forEach(b => consider(b.position_x, b.position_y))
-  props.stageBlocks?.forEach(b => consider(b.position_x, b.position_y))
+  props.blocks?.forEach(b => consider(b.position_x, b.position_y, b.colspan, b.rowspan))
+  props.stageBlocks?.forEach(b => consider(b.position_x, b.position_y, b.colspan, b.rowspan))
   props.markerBlocks?.forEach(m => {
-    if (m.type === 'comment') consider(m.position_x, m.position_y)
+    if (m.type === 'comment') consider(m.position_x, m.position_y, m.colspan, m.rowspan)
   })
 
   return {

--- a/resources/js/Components/SeatLayout.vue
+++ b/resources/js/Components/SeatLayout.vue
@@ -288,7 +288,7 @@ watch(() => props.selectedSeats, (newSeats) => {
                   <component :is="arrow(cell.rotation)" class="entrance-arrow" />
                 </div>
 
-                <div v-else-if="cell.type === 'comment'" class="comment-text">
+                <div v-else-if="cell.type === 'comment'" class="comment-text" :style="{ minWidth: `${(cell.colSpan ?? 1) * 200}px`, minHeight: `${(cell.rowSpan ?? 1) * 60}px` }">
                   {{ cell.name }}
                 </div>
               </td>
@@ -535,11 +535,11 @@ watch(() => props.selectedSeats, (newSeats) => {
 }
 
 .comment-text {
-  position: absolute;
-  inset: 8px;
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 100%;
+  height: 100%;
   padding: 6px;
   background-color: #f3f4f6;
   border: 1px solid #d1d5db;

--- a/resources/js/Components/ui/input/Input.vue
+++ b/resources/js/Components/ui/input/Input.vue
@@ -2,9 +2,9 @@
 import type { HTMLAttributes } from "vue"
 import { nextTick, ref, watch } from "vue"
 import { cn } from "@/lib/utils"
+import { coerceInputValue } from "./coerceInputValue"
 
 const props = defineProps<{
-  defaultValue?: string | number
   modelValue?: string | number
   modelModifiers?: { number?: boolean, trim?: boolean }
   class?: HTMLAttributes["class"]
@@ -24,15 +24,29 @@ const syncFromModel = () => {
   }
 }
 
-const onInput = (event: Event) => {
-  let value: string | number = (event.target as HTMLInputElement).value
-  if (props.modelModifiers?.trim) value = value.trim()
-  if (props.modelModifiers?.number) {
-    const parsed = parseFloat(value)
-    value = isNaN(parsed) ? value : parsed
-  }
+// Ignore input events while an IME composition is in progress (mirrors Vue's native
+// v-model behavior) and process the final composed value once it ends.
+const composing = ref(false)
+
+const commit = (target: HTMLInputElement) => {
+  const castNumber = props.modelModifiers?.number || target.type === "number"
+  const value = coerceInputValue(target.value, { trim: props.modelModifiers?.trim, number: castNumber })
   emits("update:modelValue", value)
   nextTick(syncFromModel)
+}
+
+const onInput = (event: Event) => {
+  if (composing.value) return
+  commit(event.target as HTMLInputElement)
+}
+
+const onCompositionStart = () => {
+  composing.value = true
+}
+
+const onCompositionEnd = (event: Event) => {
+  composing.value = false
+  commit(event.target as HTMLInputElement)
 }
 
 watch(() => props.modelValue, () => nextTick(syncFromModel))
@@ -48,6 +62,8 @@ defineExpose({
     ref="inputRef"
     :value="modelValue"
     @input="onInput"
+    @compositionstart="onCompositionStart"
+    @compositionend="onCompositionEnd"
     data-slot="input"
     :class="cn(
       'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',

--- a/resources/js/Components/ui/input/Input.vue
+++ b/resources/js/Components/ui/input/Input.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from "vue"
-import { ref } from "vue"
-import { useVModel } from "@vueuse/core"
+import { nextTick, ref, watch } from "vue"
 import { cn } from "@/lib/utils"
 
 const props = defineProps<{
   defaultValue?: string | number
   modelValue?: string | number
+  modelModifiers?: { number?: boolean, trim?: boolean }
   class?: HTMLAttributes["class"]
 }>()
 
@@ -14,12 +14,28 @@ const emits = defineEmits<{
   (e: "update:modelValue", payload: string | number): void
 }>()
 
-const modelValue = useVModel(props, "modelValue", emits, {
-  passive: true,
-  defaultValue: props.defaultValue,
-})
-
 const inputRef = ref<HTMLInputElement | null>(null)
+
+// Controlled input: force the DOM back to modelValue so a parent that rejects an edit (leaving
+// modelValue unchanged, which skips the re-render) still resets the field.
+const syncFromModel = () => {
+  if (inputRef.value && inputRef.value.value !== String(props.modelValue ?? "")) {
+    inputRef.value.value = String(props.modelValue ?? "")
+  }
+}
+
+const onInput = (event: Event) => {
+  let value: string | number = (event.target as HTMLInputElement).value
+  if (props.modelModifiers?.trim) value = value.trim()
+  if (props.modelModifiers?.number) {
+    const parsed = parseFloat(value)
+    value = isNaN(parsed) ? value : parsed
+  }
+  emits("update:modelValue", value)
+  nextTick(syncFromModel)
+}
+
+watch(() => props.modelValue, () => nextTick(syncFromModel))
 
 defineExpose({
   focus: () => inputRef.value?.focus(),
@@ -30,7 +46,8 @@ defineExpose({
 <template>
   <input
     ref="inputRef"
-    v-model="modelValue"
+    :value="modelValue"
+    @input="onInput"
     data-slot="input"
     :class="cn(
       'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',

--- a/resources/js/Components/ui/input/coerceInputValue.check.ts
+++ b/resources/js/Components/ui/input/coerceInputValue.check.ts
@@ -1,0 +1,24 @@
+// Runnable regression check for coerceInputValue (no test framework in this repo — plain asserts).
+// Run: node --experimental-strip-types resources/js/Components/ui/input/coerceInputValue.check.ts
+import assert from "node:assert/strict"
+import { coerceInputValue } from "./coerceInputValue.ts"
+
+// Plain text: passed through untouched.
+assert.equal(coerceInputValue("hello", {}), "hello")
+
+// trim modifier.
+assert.equal(coerceInputValue("  hi  ", { trim: true }), "hi")
+
+// number modifier: valid numeric string is coerced to a number.
+assert.equal(coerceInputValue("42", { number: true }), 42)
+
+// number modifier: non-numeric input is left as the original string (not NaN/dropped).
+assert.equal(coerceInputValue("abc", { number: true }), "abc")
+
+// number modifier: empty string is left as "" rather than becoming NaN.
+assert.equal(coerceInputValue("", { number: true }), "")
+
+// trim + number combined.
+assert.equal(coerceInputValue("  7  ", { trim: true, number: true }), 7)
+
+console.log("coerceInputValue: all checks passed")

--- a/resources/js/Components/ui/input/coerceInputValue.ts
+++ b/resources/js/Components/ui/input/coerceInputValue.ts
@@ -1,0 +1,12 @@
+export function coerceInputValue(
+  value: string,
+  options: { trim?: boolean, number?: boolean },
+): string | number {
+  let result: string | number = value
+  if (options.trim) result = result.trim()
+  if (options.number) {
+    const parsed = parseFloat(result)
+    result = isNaN(parsed) ? result : parsed
+  }
+  return result
+}

--- a/resources/js/Pages/Admin/RoomLayout/Edit.vue
+++ b/resources/js/Pages/Admin/RoomLayout/Edit.vue
@@ -121,22 +121,33 @@ type SelectedType = 'stage' | 'seating' | 'marker'
 
 type CellType = 'stage' | 'seating' | 'comment' | 'entrance'
 
-interface SelectedBlock {
+interface Positioned {
   id: BlockId
-  type?: CellType
   position_x: number
   position_y: number
+}
+
+interface SelectedBlock extends Positioned {
+  type?: CellType
   colspan?: number
   rowspan?: number
   rotation?: number
   markerIndex?: number
 }
 
-type PlacementCell = SelectedBlock & { type: CellType }
+type PlacementCell = SelectedBlock & {
+  type: CellType
+  name: string
+  rotation?: number
+  rows?: FormRow[]
+  orientation?: Orientation
+  colSpan?: number
+  rowSpan?: number
+}
 
 type GridCell =
   | null
-  | (PlacementCell & { colSpan: number, rowSpan: number })
+  | PlacementCell
   | { type: 'covered', id: BlockId }
 
 const selectedBlock = ref<SelectedBlock | null>(null)
@@ -182,8 +193,8 @@ const markerCells = (marker: FormMarkerBlock): Array<[number, number]> => {
 const placeSpanned = (grid: GridCell[][], cell: PlacementCell) => {
   const { position_x: x, position_y: y } = cell
   if (!inGrid(x, y)) return
-  const colSpan = Math.max(1, cell.colspan ?? 1)
-  const rowSpan = Math.max(1, cell.rowspan ?? 1)
+  const colSpan = span(cell.colspan)
+  const rowSpan = span(cell.rowspan)
   for (let dr = 0; dr < rowSpan; dr++) {
     for (let dc = 0; dc < colSpan; dc++) {
       if (!inGrid(x + dc, y + dr)) continue
@@ -194,8 +205,8 @@ const placeSpanned = (grid: GridCell[][], cell: PlacementCell) => {
   }
 }
 
-const layoutGrid = computed(() => {
-  const grid = Array(GRID_ROWS).fill(null).map(() => Array(GRID_COLS).fill(null))
+const layoutGrid = computed<GridCell[][]>(() => {
+  const grid: GridCell[][] = Array.from({ length: GRID_ROWS }, () => Array.from({ length: GRID_COLS }, (): GridCell => null))
 
   form.stageBlocks.forEach(stageBlock => placeSpanned(grid, { type: 'stage', ...stageBlock }))
   form.blocks.forEach(block => placeSpanned(grid, { type: 'seating', ...block }))
@@ -214,10 +225,8 @@ const layoutGrid = computed(() => {
   return grid
 })
 
-const getTotalSeats = (block: FormBlock) => {
-  if (!block.rows || block.rows.length === 0) return 0
-  return block.rows.reduce((total, row) => total + (row.seatCount || 0), 0)
-}
+const getTotalSeats = (rows: FormRow[] = []) =>
+  rows.reduce((total, row) => total + (row.seatCount || 0), 0)
 
 const getOrientationArrow = (rotation: number | undefined) => {
   const arrows: Record<number, typeof ArrowUp> = {
@@ -246,17 +255,41 @@ const selectBlock = (block: SelectedBlock, type: SelectedType) => {
   selectedBlockType.value = type
 }
 
-const footprintFree = (block: SelectedBlock, x: number, y: number) => {
-  const colspan = Math.max(1, block.colspan ?? 1)
-  const rowspan = Math.max(1, block.rowspan ?? 1)
-  for (let dr = 0; dr < rowspan; dr++) {
-    for (let dc = 0; dc < colspan; dc++) {
-      if (!inGrid(x + dc, y + dr)) return false
-      const cell = layoutGrid.value[y + dr][x + dc]
-      if (cell !== null && cell.id !== block.id) return false
-    }
-  }
-  return true
+interface Rect { id: BlockId, x: number, y: number, w: number, h: number }
+
+const rectsOverlap = (a: Rect, b: Rect) =>
+  a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h
+
+const blockRect = (b: SelectedBlock, x = b.position_x, y = b.position_y): Rect =>
+  ({ id: b.id, x, y, w: span(b.colspan), h: span(b.rowspan) })
+
+const rectOnGrid = (r: Rect) => inGrid(r.x, r.y) && inGrid(r.x + r.w - 1, r.y + r.h - 1)
+
+const solidBlocks = () =>
+  [...form.stageBlocks, ...form.blocks, ...form.markerBlocks.filter(m => m.type === 'comment')]
+
+const rectUnobstructed = (rect: Rect) =>
+  solidBlocks()
+    .filter(isPlaced)
+    .filter(block => block.id !== rect.id)
+    .every(block => !rectsOverlap(rect, blockRect(block)))
+
+const canPlace = (rect: Rect) => rectOnGrid(rect) && rectUnobstructed(rect)
+
+const clampSpan = (value: string | number, max: number) =>
+  Math.min(max, Math.max(1, Math.floor(Number(value)) || 1))
+
+const commitSpan = (block: SelectedBlock, axis: 'colspan' | 'rowspan', value: string | number, max: number) => {
+  const previous = span(block[axis])
+  block[axis] = clampSpan(value, max)
+
+  const resizeCollides = isPlaced(block) && !canPlace(blockRect(block))
+  if (resizeCollides) block[axis] = previous
+}
+
+const setPosition = (list: Positioned[], id: BlockId, x: number, y: number) => {
+  const target = list.find(b => b.id === id)
+  if (target) Object.assign(target, { position_x: x, position_y: y })
 }
 
 const handleCellClick = (rowIndex: number, colIndex: number) => {
@@ -264,47 +297,34 @@ const handleCellClick = (rowIndex: number, colIndex: number) => {
   const type = selectedBlockType.value
   if (!block || !type) return
 
-  if (type === 'marker' && block.type === 'entrance') {
+  if (type === 'marker') {
     if (block.markerIndex !== undefined) placeMarker(block.markerIndex, rowIndex, colIndex)
-    return
+  } else if (canPlace(blockRect(block, colIndex, rowIndex))) {
+    setPosition(type === 'stage' ? form.stageBlocks : form.blocks, block.id, colIndex, rowIndex)
   }
-  if (!footprintFree(block, colIndex, rowIndex)) return
-
-  if (type === 'stage') setPosition(form.stageBlocks, block.id, colIndex, rowIndex)
-  else if (type === 'marker') {
-    if (block.markerIndex !== undefined) placeMarker(block.markerIndex, rowIndex, colIndex)
-  } else setPosition(form.blocks, block.id, colIndex, rowIndex)
 }
 
-const setPosition = (list: Array<{ id: BlockId, position_x: number, position_y: number }>, id: BlockId, x: number, y: number) => {
-  const target = list.find(b => b.id === id)
-  if (target) Object.assign(target, { position_x: x, position_y: y })
-}
-
-const entranceAxisFree = (marker: FormMarkerBlock, orientation: Orientation, index: number) => {
-  const cells: Array<[number, number]> = orientation === 'column'
-    ? Array.from({ length: GRID_ROWS }, (_, r) => [r, index])
-    : Array.from({ length: GRID_COLS }, (_, c) => [index, c])
-  for (const [y, x] of cells) {
-    const cell = layoutGrid.value[y]?.[x]
-    if (cell !== null && cell.id !== marker.id) return false
-  }
-  return true
-}
+const entranceBand = (marker: FormMarkerBlock, orientation: Orientation, index: number): Rect =>
+  orientation === 'column'
+    ? { id: marker.id, x: index, y: 0, w: 1, h: GRID_ROWS }
+    : { id: marker.id, x: 0, y: index, w: GRID_COLS, h: 1 }
 
 const placeMarker = (markerIndex: number, rowIndex: number, colIndex: number) => {
   const marker = form.markerBlocks[markerIndex]
   if (!marker) return
+
   if (marker.type === 'comment') {
-    Object.assign(marker, { position_x: colIndex, position_y: rowIndex })
-    return
-  }
-  if (marker.orientation === 'column') {
-    if (!entranceAxisFree(marker, 'column', colIndex)) return
-    Object.assign(marker, { position_x: colIndex, position_y: -1 })
+    if (canPlace(blockRect(marker, colIndex, rowIndex))) {
+      Object.assign(marker, { position_x: colIndex, position_y: rowIndex })
+    }
+  } else if (marker.orientation === 'column') {
+    if (rectUnobstructed(entranceBand(marker, 'column', colIndex))) {
+      Object.assign(marker, { position_x: colIndex, position_y: -1 })
+    }
   } else {
-    if (!entranceAxisFree(marker, 'row', rowIndex)) return
-    Object.assign(marker, { position_x: -1, position_y: rowIndex })
+    if (rectUnobstructed(entranceBand(marker, 'row', rowIndex))) {
+      Object.assign(marker, { position_x: -1, position_y: rowIndex })
+    }
   }
 }
 
@@ -606,7 +626,7 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
 
         <Card class="p-4 gap-0">
           <div class="flex justify-between items-center" :class="{ 'mb-2': !isPanelCollapsed('stage') }">
-            <button @click="togglePanel('stage')" class="flex items-center gap-1 font-semibold">
+            <button type="button" :aria-expanded="!isPanelCollapsed('stage')" @click="togglePanel('stage')" class="flex items-center gap-1 font-semibold">
               <component :is="isPanelCollapsed('stage') ? ChevronRight : ChevronDown" class="w-4 h-4" />
               Stage Blocks
             </button>
@@ -646,11 +666,11 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
                 <div class="flex gap-4 mt-2" @click.stop>
                   <div class="flex items-center gap-2">
                     <Label class="text-xs">Cols</Label>
-                    <Input v-model.number="stageBlock.colspan" type="number" min="1" max="12" class="text-xs h-7 w-16" />
+                    <Input :model-value="stageBlock.colspan" @update:model-value="commitSpan(stageBlock, 'colspan', $event, GRID_COLS)" type="number" min="1" max="12" class="text-xs h-7 w-16" />
                   </div>
                   <div class="flex items-center gap-2">
                     <Label class="text-xs">Rows</Label>
-                    <Input v-model.number="stageBlock.rowspan" type="number" min="1" max="8" class="text-xs h-7 w-16" />
+                    <Input :model-value="stageBlock.rowspan" @update:model-value="commitSpan(stageBlock, 'rowspan', $event, GRID_ROWS)" type="number" min="1" max="8" class="text-xs h-7 w-16" />
                   </div>
                 </div>
 
@@ -666,7 +686,7 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
         <!-- Entrance Management -->
         <Card class="p-4 gap-0">
           <div class="flex justify-between items-center" :class="{ 'mb-2': !isPanelCollapsed('entrances') }">
-            <button @click="togglePanel('entrances')" class="flex items-center gap-1 font-semibold">
+            <button type="button" :aria-expanded="!isPanelCollapsed('entrances')" @click="togglePanel('entrances')" class="flex items-center gap-1 font-semibold">
               <component :is="isPanelCollapsed('entrances') ? ChevronRight : ChevronDown" class="w-4 h-4" />
               Entrances
             </button>
@@ -749,7 +769,7 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
         <!-- Comment Management -->
         <Card class="p-4 gap-0">
           <div class="flex justify-between items-center" :class="{ 'mb-2': !isPanelCollapsed('comments') }">
-            <button @click="togglePanel('comments')" class="flex items-center gap-1 font-semibold">
+            <button type="button" :aria-expanded="!isPanelCollapsed('comments')" @click="togglePanel('comments')" class="flex items-center gap-1 font-semibold">
               <component :is="isPanelCollapsed('comments') ? ChevronRight : ChevronDown" class="w-4 h-4" />
               Comments
             </button>
@@ -789,11 +809,11 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
                 <div class="flex gap-4 mb-2" @click.stop>
                   <div class="flex items-center gap-2">
                     <Label class="text-xs">Cols</Label>
-                    <Input v-model.number="marker.colspan" type="number" min="1" max="12" class="text-xs h-7 w-16" />
+                    <Input :model-value="marker.colspan" @update:model-value="commitSpan(marker, 'colspan', $event, GRID_COLS)" type="number" min="1" max="12" class="text-xs h-7 w-16" />
                   </div>
                   <div class="flex items-center gap-2">
                     <Label class="text-xs">Rows</Label>
-                    <Input v-model.number="marker.rowspan" type="number" min="1" max="8" class="text-xs h-7 w-16" />
+                    <Input :model-value="marker.rowspan" @update:model-value="commitSpan(marker, 'rowspan', $event, GRID_ROWS)" type="number" min="1" max="8" class="text-xs h-7 w-16" />
                   </div>
                 </div>
 
@@ -812,7 +832,7 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
         <!-- Seating Blocks Management -->
         <Card class="p-4 gap-0">
           <div class="flex justify-between items-center" :class="{ 'mb-2': !isPanelCollapsed('seating') }">
-            <button @click="togglePanel('seating')" class="flex items-center gap-1 font-semibold">
+            <button type="button" :aria-expanded="!isPanelCollapsed('seating')" @click="togglePanel('seating')" class="flex items-center gap-1 font-semibold">
               <component :is="isPanelCollapsed('seating') ? ChevronRight : ChevronDown" class="w-4 h-4" />
               Seating Blocks
             </button>
@@ -849,7 +869,7 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
                       @click.stop
                     />
                     <div class="text-xs text-gray-500 mt-1">
-                      {{ getTotalSeats(block) }} seats • {{ block.rows.length }} rows
+                      {{ getTotalSeats(block.rows) }} seats • {{ block.rows.length }} rows
                       <span v-if="isPlaced(block)" class="text-green-600">• Placed ({{ block.position_y }}, {{ block.position_x }})</span>
                       <span v-else class="text-orange-600">• Not placed</span>
                     </div>
@@ -882,11 +902,11 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
                 <div class="flex gap-4 mb-3">
                   <div class="flex items-center gap-2">
                     <Label class="text-xs">Cols</Label>
-                    <Input v-model.number="block.colspan" type="number" min="1" max="12" class="text-xs h-7 w-16" />
+                    <Input :model-value="block.colspan" @update:model-value="commitSpan(block, 'colspan', $event, GRID_COLS)" type="number" min="1" max="12" class="text-xs h-7 w-16" />
                   </div>
                   <div class="flex items-center gap-2">
                     <Label class="text-xs">Rows</Label>
-                    <Input v-model.number="block.rowspan" type="number" min="1" max="8" class="text-xs h-7 w-16" />
+                    <Input :model-value="block.rowspan" @update:model-value="commitSpan(block, 'rowspan', $event, GRID_ROWS)" type="number" min="1" max="8" class="text-xs h-7 w-16" />
                   </div>
                 </div>
 
@@ -1012,7 +1032,7 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
 
                       <component :is="getOrientationArrow(cell.rotation)" class="w-5 h-5 mb-1" />
 
-                      <div class="text-xs text-gray-600">{{ getTotalSeats(cell) }} seats</div>
+                      <div class="text-xs text-gray-600">{{ getTotalSeats(cell.rows) }} seats</div>
                       <div class="text-xs text-gray-500">{{ cell.rows?.length || 0 }} rows</div>
                     </div>
 

--- a/resources/js/Pages/Admin/RoomLayout/Edit.vue
+++ b/resources/js/Pages/Admin/RoomLayout/Edit.vue
@@ -52,11 +52,15 @@ const CELL_BASE = 'w-full h-full border rounded cursor-pointer flex flex-col ite
 
 const pos = (value: number | null | undefined) => (value != null ? value : -1)
 
+const span = (value: number | null | undefined) => (value != null && value >= 1 ? value : 1)
+
 const stageFromProp = (block: PropStageBlock): FormStageBlock => ({
   id: block.id,
   name: block.name,
   position_x: pos(block.position_x),
-  position_y: pos(block.position_y)
+  position_y: pos(block.position_y),
+  colspan: span(block.colspan),
+  rowspan: span(block.rowspan)
 })
 
 const markerFromProp = (block: PropMarkerBlock): FormMarkerBlock => {
@@ -72,7 +76,15 @@ const markerFromProp = (block: PropMarkerBlock): FormMarkerBlock => {
       orientation = y === -1 ? 'column' : 'row'
     }
   }
-  return { id: block.id, type: block.type, name: block.name, position_x: x, position_y: y, orientation, rotation: block.rotation || 0 }
+  return {
+    id: block.id,
+    type: block.type,
+    name: block.name,
+    position_x: x, position_y: y,
+    orientation,
+    rotation: block.rotation || 0,
+    colspan: span(block.colspan), rowspan: span(block.rowspan)
+  }
 }
 
 const rowsFromBlock = (block: PropBlock | null): FormRow[] => {
@@ -94,6 +106,8 @@ const blockFromProp = (block: PropBlock): FormBlock => ({
   position_x: pos(block.position_x),
   position_y: pos(block.position_y),
   rotation: block.rotation || 0,
+  colspan: span(block.colspan),
+  rowspan: span(block.rowspan),
   rows: rowsFromBlock(block)
 })
 
@@ -104,7 +118,28 @@ const form = useForm({
 })
 
 type SelectedType = 'stage' | 'seating' | 'marker'
-const selectedBlock = ref<any>(null)
+
+type CellType = 'stage' | 'seating' | 'comment' | 'entrance'
+
+interface SelectedBlock {
+  id: BlockId
+  type?: CellType
+  position_x: number
+  position_y: number
+  colspan?: number
+  rowspan?: number
+  rotation?: number
+  markerIndex?: number
+}
+
+type PlacementCell = SelectedBlock & { type: CellType }
+
+type GridCell =
+  | null
+  | (PlacementCell & { colSpan: number, rowSpan: number })
+  | { type: 'covered', id: BlockId }
+
+const selectedBlock = ref<SelectedBlock | null>(null)
 const selectedBlockType = ref<SelectedType | null>(null)
 const expandedBlocks = ref<Set<BlockId>>(new Set())
 const showNewBlockDialog = ref(false)
@@ -129,28 +164,39 @@ const markerOrientation = (marker: FormMarkerBlock): Orientation => (marker.posi
 
 const markerCells = (marker: FormMarkerBlock): Array<[number, number]> => {
   const { position_x: x, position_y: y } = marker
-  if (marker.type === 'comment') return [[y, x]]
   if (markerOrientation(marker) === 'column') {
     return Array.from({ length: GRID_ROWS }, (_, r) => [r, x])
   }
   return Array.from({ length: GRID_COLS }, (_, c) => [y, c])
 }
 
+const placeSpanned = (grid: GridCell[][], cell: PlacementCell) => {
+  const { position_x: x, position_y: y } = cell
+  if (!inGrid(x, y)) return
+  const colSpan = Math.max(1, cell.colspan ?? 1)
+  const rowSpan = Math.max(1, cell.rowspan ?? 1)
+  for (let dr = 0; dr < rowSpan; dr++) {
+    for (let dc = 0; dc < colSpan; dc++) {
+      if (!inGrid(x + dc, y + dr)) continue
+      grid[y + dr][x + dc] = (dr === 0 && dc === 0)
+        ? { ...cell, colSpan, rowSpan }
+        : { type: 'covered', id: cell.id }
+    }
+  }
+}
+
 const layoutGrid = computed(() => {
   const grid = Array(GRID_ROWS).fill(null).map(() => Array(GRID_COLS).fill(null))
 
-  form.stageBlocks.forEach(stageBlock => {
-    const { position_x: x, position_y: y } = stageBlock
-    if (inGrid(x, y)) grid[y][x] = { type: 'stage', ...stageBlock }
-  })
-
-  form.blocks.forEach(block => {
-    const { position_x: x, position_y: y } = block
-    if (inGrid(x, y)) grid[y][x] = { type: 'seating', ...block }
-  })
+  form.stageBlocks.forEach(stageBlock => placeSpanned(grid, { type: 'stage', ...stageBlock }))
+  form.blocks.forEach(block => placeSpanned(grid, { type: 'seating', ...block }))
 
   form.markerBlocks.forEach((marker, index) => {
     const cell = { ...marker, markerIndex: index, orientation: markerOrientation(marker) }
+    if (marker.type === 'comment') {
+      placeSpanned(grid, cell)
+      return
+    }
     for (const [y, x] of markerCells(marker)) {
       if (grid[y]?.[x] === null) grid[y][x] = cell
     }
@@ -186,9 +232,22 @@ const isBlockExpanded = (blockId: BlockId) => {
   return expandedBlocks.value.has(blockId)
 }
 
-const selectBlock = (block: any, type: SelectedType) => {
+const selectBlock = (block: SelectedBlock, type: SelectedType) => {
   selectedBlock.value = block
   selectedBlockType.value = type
+}
+
+const footprintFree = (block: SelectedBlock, x: number, y: number) => {
+  const colspan = Math.max(1, block.colspan ?? 1)
+  const rowspan = Math.max(1, block.rowspan ?? 1)
+  for (let dr = 0; dr < rowspan; dr++) {
+    for (let dc = 0; dc < colspan; dc++) {
+      if (!inGrid(x + dc, y + dr)) return false
+      const cell = layoutGrid.value[y + dr][x + dc]
+      if (cell !== null && cell.id !== block.id) return false
+    }
+  }
+  return true
 }
 
 const handleCellClick = (rowIndex: number, colIndex: number) => {
@@ -197,13 +256,15 @@ const handleCellClick = (rowIndex: number, colIndex: number) => {
   if (!block || !type) return
 
   if (type === 'marker' && block.type === 'entrance') {
-    return placeMarker(block.markerIndex, rowIndex, colIndex)
+    if (block.markerIndex !== undefined) placeMarker(block.markerIndex, rowIndex, colIndex)
+    return
   }
-  if (layoutGrid.value[rowIndex][colIndex] !== null) return
+  if (!footprintFree(block, colIndex, rowIndex)) return
 
   if (type === 'stage') setPosition(form.stageBlocks, block.id, colIndex, rowIndex)
-  else if (type === 'marker') placeMarker(block.markerIndex, rowIndex, colIndex)
-  else setPosition(form.blocks, block.id, colIndex, rowIndex)
+  else if (type === 'marker') {
+    if (block.markerIndex !== undefined) placeMarker(block.markerIndex, rowIndex, colIndex)
+  } else setPosition(form.blocks, block.id, colIndex, rowIndex)
 }
 
 const setPosition = (list: Array<{ id: BlockId, position_x: number, position_y: number }>, id: BlockId, x: number, y: number) => {
@@ -237,6 +298,8 @@ const addStageBlock = () => {
   form.stageBlocks.push({
     id: nextTempKey(),
     name: `Stage ${form.stageBlocks.length + 1}`,
+    colspan: 1,
+    rowspan: 1,
     ...UNPLACED
   })
 }
@@ -248,14 +311,14 @@ const removeStageBlock = (index: number) => {
 }
 
 const ENTRANCE_DIRECTIONS: Record<Orientation, number[]> = {
-  row: [180, 0],
+  row: [0, 180],
   column: [90, 270]
 }
 
 const addMarker = (type: MarkerType) => {
   const id = nextTempKey()
   if (type === 'comment') {
-    form.markerBlocks.push({ id, type, name: 'Note', ...UNPLACED })
+    form.markerBlocks.push({ id, type, name: 'Note', colspan: 1, rowspan: 1, ...UNPLACED })
     return
   }
   const count = form.markerBlocks.filter(m => m.type === 'entrance').length
@@ -265,6 +328,8 @@ const addMarker = (type: MarkerType) => {
     name: count === 0 ? 'Entrance' : `Entrance ${count + 1}`,
     orientation: 'row',
     rotation: ENTRANCE_DIRECTIONS.row[0],
+    colspan: 1,
+    rowspan: 1,
     ...UNPLACED
   })
 }
@@ -335,7 +400,9 @@ const toStagePayload = (s: FormStageBlock) => ({
   id: s.id,
   name: s.name,
   position_x: s.position_x,
-  position_y: s.position_y
+  position_y: s.position_y,
+  colspan: s.colspan,
+  rowspan: s.rowspan
 })
 
 const toMarkerPayload = (m: FormMarkerBlock) => ({
@@ -344,7 +411,9 @@ const toMarkerPayload = (m: FormMarkerBlock) => ({
   name: m.name,
   position_x: m.position_x,
   position_y: m.position_y,
-  rotation: m.rotation ?? 0
+  rotation: m.rotation ?? 0,
+  colspan: m.colspan,
+  rowspan: m.rowspan
 })
 
 const toRowPayload = (r: FormRow) => ({
@@ -360,6 +429,8 @@ interface BlockPayload {
   position_x: number
   position_y: number
   rotation: number
+  colspan: number
+  rowspan: number
   rowsData: ReturnType<typeof toRowPayload>[] // always >= 1 row; seeded on load, guarded on removal
 }
 
@@ -369,6 +440,8 @@ const toBlockPayload = (b: FormBlock): BlockPayload => ({
   position_x: b.position_x,
   position_y: b.position_y,
   rotation: b.rotation,
+  colspan: b.colspan,
+  rowspan: b.rowspan,
   rowsData: b.rows.map(toRowPayload)
 })
 
@@ -448,6 +521,8 @@ const createNewBlock = () => {
     position_x: x,
     position_y: y,
     rotation: 0,
+    colspan: 1,
+    rowspan: 1,
     rows: rowsFromBlock(null)
   })
 
@@ -546,6 +621,17 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
                   </Button>
                 </div>
 
+                <div class="flex gap-4 mt-2" @click.stop>
+                  <div class="flex items-center gap-2">
+                    <Label class="text-xs">Cols</Label>
+                    <Input v-model.number="stageBlock.colspan" type="number" min="1" max="12" class="text-xs h-7 w-16" />
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <Label class="text-xs">Rows</Label>
+                    <Input v-model.number="stageBlock.rowspan" type="number" min="1" max="8" class="text-xs h-7 w-16" />
+                  </div>
+                </div>
+
                 <div class="text-xs text-gray-500 mt-2">
                   <span v-if="isPlaced(stageBlock)" class="text-green-600">• Placed ({{ stageBlock.position_y }}, {{ stageBlock.position_x }})</span>
                   <span v-else class="text-orange-600">• Not placed</span>
@@ -624,6 +710,17 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
                   >
                     <RotateCw class="w-4 h-4" />
                   </Button>
+                </div>
+              </div>
+
+              <div v-if="marker.type === 'comment'" class="flex gap-4 mb-2" @click.stop>
+                <div class="flex items-center gap-2">
+                  <Label class="text-xs">Cols</Label>
+                  <Input v-model.number="marker.colspan" type="number" min="1" max="12" class="text-xs h-7 w-16" />
+                </div>
+                <div class="flex items-center gap-2">
+                  <Label class="text-xs">Rows</Label>
+                  <Input v-model.number="marker.rowspan" type="number" min="1" max="8" class="text-xs h-7 w-16" />
                 </div>
               </div>
 
@@ -709,6 +806,17 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
               </div>
 
               <div v-if="isBlockExpanded(block.id)" class="border-t bg-gray-50 p-3">
+                <div class="flex gap-4 mb-3">
+                  <div class="flex items-center gap-2">
+                    <Label class="text-xs">Cols</Label>
+                    <Input v-model.number="block.colspan" type="number" min="1" max="12" class="text-xs h-7 w-16" />
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <Label class="text-xs">Rows</Label>
+                    <Input v-model.number="block.rowspan" type="number" min="1" max="8" class="text-xs h-7 w-16" />
+                  </div>
+                </div>
+
                 <div class="flex justify-between items-center mb-2">
                   <Label class="text-xs">Row Configuration ({{ block.rows.length }} rows)</Label>
                   <div class="flex gap-1">
@@ -794,11 +902,13 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
           <div class="overflow-auto">
             <table class="layout-table w-full border-collapse border border-gray-300">
               <tbody>
-                <tr v-for="(row, rowIndex) in layoutGrid" :key="rowIndex">
+                <tr v-for="(row, rowIndex) in layoutGrid" :key="rowIndex" class="layout-row">
+                  <template v-for="(cell, colIndex) in row" :key="colIndex">
                   <td
-                    v-for="(cell, colIndex) in row"
-                    :key="colIndex"
-                    class="layout-cell border border-gray-300 w-24 h-24 p-1 relative"
+                    v-if="cell?.type !== 'covered'"
+                    :colspan="cell?.colSpan || 1"
+                    :rowspan="cell?.rowSpan || 1"
+                    class="layout-cell border border-gray-300 w-24 p-1 relative"
                     :class="{
                       'bg-gray-50': cell === null,
                       'bg-red-100': cell?.type === 'stage',
@@ -850,6 +960,7 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
                       <div class="text-xs whitespace-normal break-words">{{ cell.name }}</div>
                     </div>
                   </td>
+                  </template>
                 </tr>
               </tbody>
             </table>
@@ -971,24 +1082,35 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
   min-width: 800px;
 }
 
+.layout-row {
+  height: 96px;
+}
+
 .layout-cell {
   min-width: 96px;
-  min-height: 96px;
+  height: 96px;
   position: relative;
   transition: background-color 0.2s ease;
+}
+
+.layout-cell > div {
+  position: absolute;
+  inset: 4px;
+  width: auto;
+  height: auto;
 }
 
 .layout-cell:hover {
   background-color: #f0f9ff !important;
 }
 
-.layout-cell .bg-white {
-  transition: all 0.2s ease;
+.layout-cell > div.cursor-pointer {
+  transition: inset 0.15s ease;
 }
 
-.layout-cell .bg-white:hover {
-  transform: scale(1.02);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+.layout-cell > div.cursor-pointer:hover {
+  inset: 2px;
+  z-index: 10;
 }
 
 .text-lg {
@@ -1001,16 +1123,24 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
     min-width: 600px;
   }
 
+  .layout-row {
+    height: 80px;
+  }
+
   .layout-cell {
     min-width: 80px;
-    min-height: 80px;
+    height: 80px;
   }
 }
 
 @media (max-width: 768px) {
+  .layout-row {
+    height: 60px;
+  }
+
   .layout-cell {
     min-width: 60px;
-    min-height: 60px;
+    height: 60px;
   }
 
   .layout-cell .text-xs {

--- a/resources/js/Pages/Admin/RoomLayout/Edit.vue
+++ b/resources/js/Pages/Admin/RoomLayout/Edit.vue
@@ -13,6 +13,7 @@ import type {
   PropBlock, PropStageBlock, PropMarkerBlock,
   FormBlock, FormStageBlock, FormMarkerBlock, FormRow
 } from '@/types/layout'
+import { span, blockRect as pureBlockRect, canPlace as pureCanPlace, rectUnobstructed as pureRectUnobstructed, rectsOverlap, clampSpan, type Rect as PureRect } from '@/lib/layoutGrid'
 
 defineOptions({ layout: AdminLayout })
 
@@ -51,8 +52,6 @@ const isPlaced = (block: { position_x: number, position_y: number }) => block.po
 const CELL_BASE = 'w-full h-full border rounded cursor-pointer flex flex-col items-center justify-center text-center hover:shadow-md transition-shadow'
 
 const pos = (value: number | null | undefined) => (value != null ? value : -1)
-
-const span = (value: number | null | undefined) => (value != null && value >= 1 ? value : 1)
 
 const stageFromProp = (block: PropStageBlock): FormStageBlock => ({
   id: block.id,
@@ -255,29 +254,44 @@ const selectBlock = (block: SelectedBlock, type: SelectedType) => {
   selectedBlockType.value = type
 }
 
-interface Rect { id: BlockId, x: number, y: number, w: number, h: number }
+type Rect = PureRect
 
-const rectsOverlap = (a: Rect, b: Rect) =>
-  a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h
+const blockRect = (b: SelectedBlock, x = b.position_x, y = b.position_y): Rect => pureBlockRect(b, x, y)
 
-const blockRect = (b: SelectedBlock, x = b.position_x, y = b.position_y): Rect =>
-  ({ id: b.id, x, y, w: span(b.colspan), h: span(b.rowspan) })
-
-const rectOnGrid = (r: Rect) => inGrid(r.x, r.y) && inGrid(r.x + r.w - 1, r.y + r.h - 1)
+const entranceBand = (marker: FormMarkerBlock, orientation: Orientation, index: number): Rect =>
+  orientation === 'column'
+    ? { id: marker.id, x: index, y: 0, w: 1, h: GRID_ROWS }
+    : { id: marker.id, x: 0, y: index, w: GRID_COLS, h: 1 }
 
 const solidBlocks = () =>
   [...form.stageBlocks, ...form.blocks, ...form.markerBlocks.filter(m => m.type === 'comment')]
 
-const rectUnobstructed = (rect: Rect) =>
-  solidBlocks()
-    .filter(isPlaced)
-    .filter(block => block.id !== rect.id)
-    .every(block => !rectsOverlap(rect, blockRect(block)))
+// Placed entrances as rects, so stage/seating/comment placement can't land on an entrance's
+// row/column. Optionally narrowed to one orientation for the entrance-vs-entrance check below
+// (row and column entrances are allowed to cross, so that check must ignore the other axis).
+const entranceRects = (orientation?: Orientation, excludeId?: BlockId) =>
+  form.markerBlocks
+    .filter((m): m is FormMarkerBlock => m.type === 'entrance' && m.id !== excludeId && isPlaced(m) && (orientation === undefined || m.orientation === orientation))
+    .map(m => entranceBand(m, m.orientation ?? 'row', m.orientation === 'column' ? m.position_x : m.position_y))
 
-const canPlace = (rect: Rect) => rectOnGrid(rect) && rectUnobstructed(rect)
+const obstacles = () => [
+  ...solidBlocks().filter(isPlaced).map(block => blockRect(block)),
+  ...entranceRects(),
+]
 
-const clampSpan = (value: string | number, max: number) =>
-  Math.min(max, Math.max(1, Math.floor(Number(value)) || 1))
+const canPlace = (rect: Rect) => pureCanPlace(rect, GRID_COLS, GRID_ROWS, obstacles().filter(o => o.id !== rect.id))
+
+// Entrances only collide with solid blocks and with another entrance on the same axis/index
+// (mirrors the pre-colspan duplicate check) - not routed through obstacles()/canPlace() since
+// those now include entrances of both orientations, which would wrongly reject a row entrance
+// crossing a column entrance.
+const canPlaceEntrance = (marker: FormMarkerBlock, orientation: Orientation, index: number) => {
+  const rect = entranceBand(marker, orientation, index)
+  const blockObstacles = solidBlocks().filter(isPlaced).map(block => blockRect(block))
+  if (!pureRectUnobstructed(rect, blockObstacles)) return false
+
+  return !entranceRects(orientation, marker.id).some(other => rectsOverlap(rect, other))
+}
 
 const commitSpan = (block: SelectedBlock, axis: 'colspan' | 'rowspan', value: string | number, max: number) => {
   const previous = span(block[axis])
@@ -304,11 +318,6 @@ const handleCellClick = (rowIndex: number, colIndex: number) => {
   }
 }
 
-const entranceBand = (marker: FormMarkerBlock, orientation: Orientation, index: number): Rect =>
-  orientation === 'column'
-    ? { id: marker.id, x: index, y: 0, w: 1, h: GRID_ROWS }
-    : { id: marker.id, x: 0, y: index, w: GRID_COLS, h: 1 }
-
 const placeMarker = (markerIndex: number, rowIndex: number, colIndex: number) => {
   const marker = form.markerBlocks[markerIndex]
   if (!marker) return
@@ -318,11 +327,11 @@ const placeMarker = (markerIndex: number, rowIndex: number, colIndex: number) =>
       Object.assign(marker, { position_x: colIndex, position_y: rowIndex })
     }
   } else if (marker.orientation === 'column') {
-    if (rectUnobstructed(entranceBand(marker, 'column', colIndex))) {
+    if (canPlaceEntrance(marker, 'column', colIndex)) {
       Object.assign(marker, { position_x: colIndex, position_y: -1 })
     }
   } else {
-    if (rectUnobstructed(entranceBand(marker, 'row', rowIndex))) {
+    if (canPlaceEntrance(marker, 'row', rowIndex)) {
       Object.assign(marker, { position_x: -1, position_y: rowIndex })
     }
   }
@@ -663,7 +672,7 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
                   </Button>
                 </div>
 
-                <div class="flex gap-4 mt-2" @click.stop>
+                <div class="flex gap-4" @click.stop>
                   <div class="flex items-center gap-2">
                     <Label class="text-xs">Cols</Label>
                     <Input :model-value="stageBlock.colspan" @update:model-value="commitSpan(stageBlock, 'colspan', $event, GRID_COLS)" type="number" min="1" max="12" class="text-xs h-7 w-16" />

--- a/resources/js/Pages/Admin/RoomLayout/Edit.vue
+++ b/resources/js/Pages/Admin/RoomLayout/Edit.vue
@@ -7,7 +7,7 @@ import { Card } from '@/Components/ui/card'
 import { Input } from '@/Components/ui/input'
 import { Label } from '@/Components/ui/label'
 import { useToast } from '@/Components/ui/toast'
-import { Trash2, RotateCw, ArrowUp, ArrowRight, ArrowDown, ArrowLeft, TriangleAlert } from 'lucide-vue-next'
+import { Trash2, RotateCw, ArrowUp, ArrowRight, ArrowDown, ArrowLeft, TriangleAlert, ChevronDown, ChevronRight } from 'lucide-vue-next'
 import type {
   BlockId, Orientation, MarkerType,
   PropBlock, PropStageBlock, PropMarkerBlock,
@@ -142,6 +142,15 @@ type GridCell =
 const selectedBlock = ref<SelectedBlock | null>(null)
 const selectedBlockType = ref<SelectedType | null>(null)
 const expandedBlocks = ref<Set<BlockId>>(new Set())
+
+type PanelKey = 'stage' | 'entrances' | 'comments' | 'seating'
+const collapsedPanels = ref<Set<PanelKey>>(new Set())
+const togglePanel = (panel: PanelKey) => {
+  collapsedPanels.value.has(panel)
+    ? collapsedPanels.value.delete(panel)
+    : collapsedPanels.value.add(panel)
+}
+const isPanelCollapsed = (panel: PanelKey) => collapsedPanels.value.has(panel)
 const showNewBlockDialog = ref(false)
 const newBlockName = ref('')
 
@@ -586,14 +595,17 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
       <div class="lg:col-span-2 space-y-4">
 
         <Card class="p-4 gap-0">
-          <div class="flex justify-between items-center mb-2">
-            <h3 class="font-semibold">Stage Blocks</h3>
+          <div class="flex justify-between items-center" :class="{ 'mb-2': !isPanelCollapsed('stage') }">
+            <button @click="togglePanel('stage')" class="flex items-center gap-1 font-semibold">
+              <component :is="isPanelCollapsed('stage') ? ChevronRight : ChevronDown" class="w-4 h-4" />
+              Stage Blocks
+            </button>
             <Button size="sm" variant="outline" class="text-xs" @click="addStageBlock">
               + Add Stage
             </Button>
           </div>
 
-          <div class="space-y-2 max-h-96 overflow-y-auto">
+          <div v-show="!isPanelCollapsed('stage')" class="space-y-2 max-h-96 overflow-y-auto">
             <div
               v-for="(stageBlock, index) in form.stageBlocks"
               :key="stageBlock.id"
@@ -641,114 +653,165 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
           </div>
         </Card>
 
-        <!-- Marker Blocks Management -->
+        <!-- Entrance Management -->
         <Card class="p-4 gap-0">
-          <div class="flex justify-between items-center mb-2">
-            <h3 class="font-semibold">Markers</h3>
-            <div class="flex gap-1">
-              <Button size="sm" variant="outline" class="text-xs" @click="addMarker('entrance')">
-                + Entrance
-              </Button>
-              <Button size="sm" variant="outline" class="text-xs" @click="addMarker('comment')">
-                + Comment
-              </Button>
-            </div>
+          <div class="flex justify-between items-center" :class="{ 'mb-2': !isPanelCollapsed('entrances') }">
+            <button @click="togglePanel('entrances')" class="flex items-center gap-1 font-semibold">
+              <component :is="isPanelCollapsed('entrances') ? ChevronRight : ChevronDown" class="w-4 h-4" />
+              Entrances
+            </button>
+            <Button size="sm" variant="outline" class="text-xs" @click="addMarker('entrance')">
+              + Entrance
+            </Button>
           </div>
 
-          <div class="space-y-2 max-h-96 overflow-y-auto">
-            <div
-              v-for="(marker, index) in form.markerBlocks"
-              :key="marker.id"
-              class="border border-gray-200 rounded-lg p-3"
-              :class="{ 'ring-2 ring-inset ring-amber-500': selectedBlockType === 'marker' && selectedBlock?.markerIndex === index }"
-              @click="selectBlock({ ...marker, markerIndex: index }, 'marker')"
-            >
-              <div class="flex items-end justify-between mb-2">
-                <div class="flex-1">
-                  <Label class="text-xs">
-                    {{ marker.type === 'entrance' ? 'Entrance label' : 'Comment text' }}
-                  </Label>
-                  <Input
-                    v-model="marker.name"
-                    class="text-sm mt-1"
-                    @click.stop
-                  />
-                </div>
-                <Button
-                  size="sm"
-                  variant="destructive"
-                  @click.stop="removeMarkerBlock(index)"
-                  class="text-xs px-2 py-1 ml-2"
-                  title="Remove marker"
-                >
-                  <Trash2 class="w-4 h-4" />
-                </Button>
-              </div>
-
-              <div v-if="marker.type === 'entrance'" class="space-y-2 mb-2">
-                <div class="flex items-center gap-2">
-                  <Label class="text-xs w-16">Spans</Label>
-                  <select
-                    :value="marker.orientation"
-                    @click.stop
-                    @change="setEntranceOrientation(marker, ($event.target as HTMLSelectElement).value as Orientation)"
-                    class="text-xs h-7 border border-gray-300 rounded px-2 flex-1"
-                  >
-                    <option value="row">Full row (horizontal)</option>
-                    <option value="column">Full column (vertical)</option>
-                  </select>
-                </div>
-                <div class="flex items-center gap-2">
-                  <Label class="text-xs w-16">Direction</Label>
-                  <component :is="getOrientationArrow(marker.rotation)" class="w-5 h-5" />
+          <div v-show="!isPanelCollapsed('entrances')" class="space-y-2 max-h-96 overflow-y-auto">
+            <template v-for="(marker, index) in form.markerBlocks" :key="marker.id">
+              <div
+                v-if="marker.type === 'entrance'"
+                class="border border-gray-200 rounded-lg p-3"
+                :class="{ 'ring-2 ring-inset ring-amber-500': selectedBlockType === 'marker' && selectedBlock?.markerIndex === index }"
+                @click="selectBlock({ ...marker, markerIndex: index }, 'marker')"
+              >
+                <div class="flex items-end justify-between mb-2">
+                  <div class="flex-1">
+                    <Label class="text-xs">Entrance label</Label>
+                    <Input
+                      v-model="marker.name"
+                      class="text-sm mt-1"
+                      @click.stop
+                    />
+                  </div>
                   <Button
                     size="sm"
-                    variant="outline"
-                    @click.stop="rotateEntrance(marker)"
-                    class="text-xs px-2 py-1"
-                    title="Rotate direction"
+                    variant="destructive"
+                    @click.stop="removeMarkerBlock(index)"
+                    class="text-xs px-2 py-1 ml-2"
+                    title="Remove entrance"
                   >
-                    <RotateCw class="w-4 h-4" />
+                    <Trash2 class="w-4 h-4" />
                   </Button>
                 </div>
-              </div>
 
-              <div v-if="marker.type === 'comment'" class="flex gap-4 mb-2" @click.stop>
-                <div class="flex items-center gap-2">
-                  <Label class="text-xs">Cols</Label>
-                  <Input v-model.number="marker.colspan" type="number" min="1" max="12" class="text-xs h-7 w-16" />
+                <div class="space-y-2 mb-2">
+                  <div class="flex items-center gap-2">
+                    <Label class="text-xs w-16">Spans</Label>
+                    <select
+                      :value="marker.orientation"
+                      @click.stop
+                      @change="setEntranceOrientation(marker, ($event.target as HTMLSelectElement).value as Orientation)"
+                      class="text-xs h-7 border border-gray-300 rounded px-2 flex-1"
+                    >
+                      <option value="row">Full row (horizontal)</option>
+                      <option value="column">Full column (vertical)</option>
+                    </select>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <Label class="text-xs w-16">Direction</Label>
+                    <component :is="getOrientationArrow(marker.rotation)" class="w-5 h-5" />
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      @click.stop="rotateEntrance(marker)"
+                      class="text-xs px-2 py-1"
+                      title="Rotate direction"
+                    >
+                      <RotateCw class="w-4 h-4" />
+                    </Button>
+                  </div>
                 </div>
-                <div class="flex items-center gap-2">
-                  <Label class="text-xs">Rows</Label>
-                  <Input v-model.number="marker.rowspan" type="number" min="1" max="8" class="text-xs h-7 w-16" />
-                </div>
-              </div>
 
-              <div class="text-xs text-gray-500">
-                <span v-if="getMarkerPlacementStatus(marker)" class="text-green-600">
-                  <template v-if="marker.type === 'comment'">• Placed ({{ marker.position_y }}, {{ marker.position_x }})</template>
-                  <template v-else-if="marker.orientation === 'column'">• Column {{ marker.position_x }}</template>
-                  <template v-else>• Row {{ marker.position_y }}</template>
-                </span>
-                <span v-else class="text-orange-600">• Not placed</span>
+                <div class="text-xs text-gray-500">
+                  <span v-if="getMarkerPlacementStatus(marker)" class="text-green-600">
+                    <template v-if="marker.orientation === 'column'">• Column {{ marker.position_x }}</template>
+                    <template v-else>• Row {{ marker.position_y }}</template>
+                  </span>
+                  <span v-else class="text-orange-600">• Not placed</span>
+                </div>
               </div>
-            </div>
-            <p v-if="form.markerBlocks.length === 0" class="text-xs text-gray-400">
-              No markers yet. Add an entrance row/column or a comment note.
+            </template>
+            <p v-if="!form.markerBlocks.some(m => m.type === 'entrance')" class="text-xs text-gray-400">
+              No entrances yet. Add an entrance row or column.
+            </p>
+          </div>
+        </Card>
+
+        <!-- Comment Management -->
+        <Card class="p-4 gap-0">
+          <div class="flex justify-between items-center" :class="{ 'mb-2': !isPanelCollapsed('comments') }">
+            <button @click="togglePanel('comments')" class="flex items-center gap-1 font-semibold">
+              <component :is="isPanelCollapsed('comments') ? ChevronRight : ChevronDown" class="w-4 h-4" />
+              Comments
+            </button>
+            <Button size="sm" variant="outline" class="text-xs" @click="addMarker('comment')">
+              + Comment
+            </Button>
+          </div>
+
+          <div v-show="!isPanelCollapsed('comments')" class="space-y-2 max-h-96 overflow-y-auto">
+            <template v-for="(marker, index) in form.markerBlocks" :key="marker.id">
+              <div
+                v-if="marker.type === 'comment'"
+                class="border border-gray-200 rounded-lg p-3"
+                :class="{ 'ring-2 ring-inset ring-amber-500': selectedBlockType === 'marker' && selectedBlock?.markerIndex === index }"
+                @click="selectBlock({ ...marker, markerIndex: index }, 'marker')"
+              >
+                <div class="flex items-end justify-between mb-2">
+                  <div class="flex-1">
+                    <Label class="text-xs">Comment text</Label>
+                    <Input
+                      v-model="marker.name"
+                      class="text-sm mt-1"
+                      @click.stop
+                    />
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    @click.stop="removeMarkerBlock(index)"
+                    class="text-xs px-2 py-1 ml-2"
+                    title="Remove comment"
+                  >
+                    <Trash2 class="w-4 h-4" />
+                  </Button>
+                </div>
+
+                <div class="flex gap-4 mb-2" @click.stop>
+                  <div class="flex items-center gap-2">
+                    <Label class="text-xs">Cols</Label>
+                    <Input v-model.number="marker.colspan" type="number" min="1" max="12" class="text-xs h-7 w-16" />
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <Label class="text-xs">Rows</Label>
+                    <Input v-model.number="marker.rowspan" type="number" min="1" max="8" class="text-xs h-7 w-16" />
+                  </div>
+                </div>
+
+                <div class="text-xs text-gray-500">
+                  <span v-if="getMarkerPlacementStatus(marker)" class="text-green-600">• Placed ({{ marker.position_y }}, {{ marker.position_x }})</span>
+                  <span v-else class="text-orange-600">• Not placed</span>
+                </div>
+              </div>
+            </template>
+            <p v-if="!form.markerBlocks.some(m => m.type === 'comment')" class="text-xs text-gray-400">
+              No comments yet. Add a comment note.
             </p>
           </div>
         </Card>
 
         <!-- Seating Blocks Management -->
         <Card class="p-4 gap-0">
-          <div class="flex justify-between items-center mb-2">
-            <h3 class="font-semibold">Seating Blocks</h3>
+          <div class="flex justify-between items-center" :class="{ 'mb-2': !isPanelCollapsed('seating') }">
+            <button @click="togglePanel('seating')" class="flex items-center gap-1 font-semibold">
+              <component :is="isPanelCollapsed('seating') ? ChevronRight : ChevronDown" class="w-4 h-4" />
+              Seating Blocks
+            </button>
             <Button size="sm" variant="outline" class="text-xs" @click="openNewBlockDialog">
               + Add Block
             </Button>
           </div>
 
-          <div class="space-y-2 overflow-y-auto">
+          <div v-show="!isPanelCollapsed('seating')" class="space-y-2 overflow-y-auto">
             <div
               v-for="block in form.blocks"
               :key="block.id"

--- a/resources/js/Pages/Admin/RoomLayout/Edit.vue
+++ b/resources/js/Pages/Admin/RoomLayout/Edit.vue
@@ -281,6 +281,17 @@ const setPosition = (list: Array<{ id: BlockId, position_x: number, position_y: 
   if (target) Object.assign(target, { position_x: x, position_y: y })
 }
 
+const entranceAxisFree = (marker: FormMarkerBlock, orientation: Orientation, index: number) => {
+  const cells: Array<[number, number]> = orientation === 'column'
+    ? Array.from({ length: GRID_ROWS }, (_, r) => [r, index])
+    : Array.from({ length: GRID_COLS }, (_, c) => [index, c])
+  for (const [y, x] of cells) {
+    const cell = layoutGrid.value[y]?.[x]
+    if (cell !== null && cell.id !== marker.id) return false
+  }
+  return true
+}
+
 const placeMarker = (markerIndex: number, rowIndex: number, colIndex: number) => {
   const marker = form.markerBlocks[markerIndex]
   if (!marker) return
@@ -288,12 +299,11 @@ const placeMarker = (markerIndex: number, rowIndex: number, colIndex: number) =>
     Object.assign(marker, { position_x: colIndex, position_y: rowIndex })
     return
   }
-  const others = form.markerBlocks.filter((_, i) => i !== markerIndex)
   if (marker.orientation === 'column') {
-    if (others.some(m => m.orientation === 'column' && m.position_x === colIndex)) return
+    if (!entranceAxisFree(marker, 'column', colIndex)) return
     Object.assign(marker, { position_x: colIndex, position_y: -1 })
   } else {
-    if (others.some(m => m.orientation === 'row' && m.position_y === rowIndex)) return
+    if (!entranceAxisFree(marker, 'row', rowIndex)) return
     Object.assign(marker, { position_x: -1, position_y: rowIndex })
   }
 }

--- a/resources/js/Pages/Admin/RoomLayout/Edit.vue
+++ b/resources/js/Pages/Admin/RoomLayout/Edit.vue
@@ -140,8 +140,8 @@ type PlacementCell = SelectedBlock & {
   rotation?: number
   rows?: FormRow[]
   orientation?: Orientation
-  colSpan?: number
-  rowSpan?: number
+  gridColSpan?: number
+  gridRowSpan?: number
 }
 
 type GridCell =
@@ -196,9 +196,11 @@ const placeSpanned = (grid: GridCell[][], cell: PlacementCell) => {
   const rowSpan = span(cell.rowspan)
   for (let dr = 0; dr < rowSpan; dr++) {
     for (let dc = 0; dc < colSpan; dc++) {
+      // Persisted block positions/spans are expected to be validated (grid bounds + overlap)
+      // server-side before reaching this computed; a skipped cell here means legacy/inconsistent data.
       if (!inGrid(x + dc, y + dr)) continue
       grid[y + dr][x + dc] = (dr === 0 && dc === 0)
-        ? { ...cell, colSpan, rowSpan }
+        ? { ...cell, gridColSpan: colSpan, gridRowSpan: rowSpan }
         : { type: 'covered', id: cell.id }
     }
   }
@@ -313,8 +315,16 @@ const handleCellClick = (rowIndex: number, colIndex: number) => {
 
   if (type === 'marker') {
     if (block.markerIndex !== undefined) placeMarker(block.markerIndex, rowIndex, colIndex)
-  } else if (canPlace(blockRect(block, colIndex, rowIndex))) {
-    setPosition(type === 'stage' ? form.stageBlocks : form.blocks, block.id, colIndex, rowIndex)
+    return
+  }
+
+  // selectedBlock may be a snapshot (e.g. selected via a grid cell) whose span is stale
+  // relative to live edits made through the side panel since selection - re-fetch by id
+  // so validation uses the block's current colspan/rowspan.
+  const list = type === 'stage' ? form.stageBlocks : form.blocks
+  const current = list.find(b => b.id === block.id)
+  if (current && canPlace(blockRect(current, colIndex, rowIndex))) {
+    setPosition(list, current.id, colIndex, rowIndex)
   }
 }
 
@@ -1012,8 +1022,8 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
                   <template v-for="(cell, colIndex) in row" :key="colIndex">
                   <td
                     v-if="cell?.type !== 'covered'"
-                    :colspan="cell?.colSpan || 1"
-                    :rowspan="cell?.rowSpan || 1"
+                    :colspan="cell?.gridColSpan || 1"
+                    :rowspan="cell?.gridRowSpan || 1"
                     class="layout-cell border border-gray-300 w-24 p-1 relative"
                     :class="{
                       'bg-gray-50': cell === null,

--- a/resources/js/Pages/Admin/RoomLayout/Edit.vue
+++ b/resources/js/Pages/Admin/RoomLayout/Edit.vue
@@ -672,13 +672,14 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
                   </Button>
                 </div>
 
+                <p class="text-xs text-gray-400 mt-2 mb-1">Grid cells this block occupies (width × height)</p>
                 <div class="flex gap-4" @click.stop>
                   <div class="flex items-center gap-2">
-                    <Label class="text-xs">Cols</Label>
+                    <Label class="text-xs">Width</Label>
                     <Input :model-value="stageBlock.colspan" @update:model-value="commitSpan(stageBlock, 'colspan', $event, GRID_COLS)" type="number" min="1" max="12" class="text-xs h-7 w-16" />
                   </div>
                   <div class="flex items-center gap-2">
-                    <Label class="text-xs">Rows</Label>
+                    <Label class="text-xs">Height</Label>
                     <Input :model-value="stageBlock.rowspan" @update:model-value="commitSpan(stageBlock, 'rowspan', $event, GRID_ROWS)" type="number" min="1" max="8" class="text-xs h-7 w-16" />
                   </div>
                 </div>
@@ -815,13 +816,14 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
                   </Button>
                 </div>
 
+                <p class="text-xs text-gray-400 mb-1">Grid cells this block occupies (width × height)</p>
                 <div class="flex gap-4 mb-2" @click.stop>
                   <div class="flex items-center gap-2">
-                    <Label class="text-xs">Cols</Label>
+                    <Label class="text-xs">Width</Label>
                     <Input :model-value="marker.colspan" @update:model-value="commitSpan(marker, 'colspan', $event, GRID_COLS)" type="number" min="1" max="12" class="text-xs h-7 w-16" />
                   </div>
                   <div class="flex items-center gap-2">
-                    <Label class="text-xs">Rows</Label>
+                    <Label class="text-xs">Height</Label>
                     <Input :model-value="marker.rowspan" @update:model-value="commitSpan(marker, 'rowspan', $event, GRID_ROWS)" type="number" min="1" max="8" class="text-xs h-7 w-16" />
                   </div>
                 </div>
@@ -908,17 +910,19 @@ const removeSpecificRow = (block: FormBlock, rowNumber: number) => {
               </div>
 
               <div v-if="isBlockExpanded(block.id)" class="border-t bg-gray-50 p-3">
+                <p class="text-xs text-gray-400 mb-1">Grid cells this block occupies (width × height)</p>
                 <div class="flex gap-4 mb-3">
                   <div class="flex items-center gap-2">
-                    <Label class="text-xs">Cols</Label>
+                    <Label class="text-xs">Width</Label>
                     <Input :model-value="block.colspan" @update:model-value="commitSpan(block, 'colspan', $event, GRID_COLS)" type="number" min="1" max="12" class="text-xs h-7 w-16" />
                   </div>
                   <div class="flex items-center gap-2">
-                    <Label class="text-xs">Rows</Label>
+                    <Label class="text-xs">Height</Label>
                     <Input :model-value="block.rowspan" @update:model-value="commitSpan(block, 'rowspan', $event, GRID_ROWS)" type="number" min="1" max="8" class="text-xs h-7 w-16" />
                   </div>
                 </div>
 
+                <p class="text-xs text-gray-400 mb-1">Number of seats per row, and how they're aligned within the block</p>
                 <div class="flex justify-between items-center mb-2">
                   <Label class="text-xs">Row Configuration ({{ block.rows.length }} rows)</Label>
                   <div class="flex gap-1">

--- a/resources/js/lib/layoutGrid.check.ts
+++ b/resources/js/lib/layoutGrid.check.ts
@@ -1,0 +1,49 @@
+// Runnable regression check for layoutGrid (no test framework in this repo — plain asserts).
+// Run: node --experimental-strip-types resources/js/lib/layoutGrid.check.ts
+import assert from "node:assert/strict"
+import { rectsOverlap, blockRect, rectOnGrid, canPlace, rectUnobstructed, clampSpan } from "./layoutGrid.ts"
+
+const COLS = 12
+const ROWS = 8
+
+// rectsOverlap: overlapping rects.
+assert.equal(rectsOverlap({ id: 1, x: 0, y: 0, w: 2, h: 2 }, { id: 2, x: 1, y: 1, w: 2, h: 2 }), true)
+
+// rectsOverlap: adjacent (touching edge) rects do not overlap.
+assert.equal(rectsOverlap({ id: 1, x: 0, y: 0, w: 2, h: 2 }, { id: 2, x: 2, y: 0, w: 2, h: 2 }), false)
+
+// blockRect: colspan/rowspan below 1 (null/undefined/0) clamp to a 1x1 footprint.
+assert.deepEqual(blockRect({ id: 1, colspan: null, rowspan: 0 }, 3, 4), { id: 1, x: 3, y: 4, w: 1, h: 1 })
+assert.deepEqual(blockRect({ id: 1, colspan: 3, rowspan: 2 }, 0, 0), { id: 1, x: 0, y: 0, w: 3, h: 2 })
+
+// rectOnGrid: within bounds.
+assert.equal(rectOnGrid({ id: 1, x: 0, y: 0, w: COLS, h: ROWS }, COLS, ROWS), true)
+
+// rectOnGrid: a span pushes the rect past the right/bottom edge.
+assert.equal(rectOnGrid({ id: 1, x: COLS - 1, y: 0, w: 2, h: 1 }, COLS, ROWS), false)
+assert.equal(rectOnGrid({ id: 1, x: 0, y: ROWS - 1, w: 1, h: 2 }, COLS, ROWS), false)
+
+// rectOnGrid: negative origin is off-grid.
+assert.equal(rectOnGrid({ id: 1, x: -1, y: 0, w: 1, h: 1 }, COLS, ROWS), false)
+
+// rectUnobstructed: ignores a rect with the same id (self), rejects a colliding neighbor.
+const others = [{ id: 1, x: 0, y: 0, w: 2, h: 2 }, { id: 2, x: 5, y: 5, w: 1, h: 1 }]
+assert.equal(rectUnobstructed({ id: 1, x: 0, y: 0, w: 2, h: 2 }, others), true)
+assert.equal(rectUnobstructed({ id: 3, x: 1, y: 1, w: 1, h: 1 }, others), false)
+
+// canPlace: off-grid rect is rejected even with no obstacles.
+assert.equal(canPlace({ id: 1, x: COLS, y: 0, w: 1, h: 1 }, COLS, ROWS, []), false)
+
+// canPlace: on-grid and unobstructed.
+assert.equal(canPlace({ id: 1, x: 0, y: 0, w: 1, h: 1 }, COLS, ROWS, []), true)
+
+// canPlace: on-grid but colliding with another block.
+assert.equal(canPlace({ id: 1, x: 0, y: 0, w: 1, h: 1 }, COLS, ROWS, [{ id: 2, x: 0, y: 0, w: 1, h: 1 }]), false)
+
+// clampSpan: clamps to [1, max] and falls back to 1 for non-numeric input.
+assert.equal(clampSpan(0, 12), 1)
+assert.equal(clampSpan(99, 12), 12)
+assert.equal(clampSpan("abc", 12), 1)
+assert.equal(clampSpan(3.9, 12), 3)
+
+console.log("layoutGrid: all checks passed")

--- a/resources/js/lib/layoutGrid.ts
+++ b/resources/js/lib/layoutGrid.ts
@@ -1,0 +1,34 @@
+// Pure grid-placement geometry shared by the room layout editor (Edit.vue).
+
+export interface Rect {
+  id: string | number
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+export const span = (value: number | null | undefined): number => (value != null && value >= 1 ? value : 1)
+
+export const rectsOverlap = (a: Rect, b: Rect): boolean =>
+  a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h
+
+export const blockRect = (
+  block: { id: Rect['id'], colspan?: number | null, rowspan?: number | null },
+  x: number,
+  y: number
+): Rect => ({ id: block.id, x, y, w: span(block.colspan), h: span(block.rowspan) })
+
+const inGrid = (x: number, y: number, cols: number, rows: number) => x >= 0 && x < cols && y >= 0 && y < rows
+
+export const rectOnGrid = (rect: Rect, cols: number, rows: number): boolean =>
+  inGrid(rect.x, rect.y, cols, rows) && inGrid(rect.x + rect.w - 1, rect.y + rect.h - 1, cols, rows)
+
+export const rectUnobstructed = (rect: Rect, others: Rect[]): boolean =>
+  others.filter(other => other.id !== rect.id).every(other => !rectsOverlap(rect, other))
+
+export const canPlace = (rect: Rect, cols: number, rows: number, others: Rect[]): boolean =>
+  rectOnGrid(rect, cols, rows) && rectUnobstructed(rect, others)
+
+export const clampSpan = (value: string | number, max: number): number =>
+  Math.min(max, Math.max(1, Math.floor(Number(value)) || 1))

--- a/resources/js/types/layout.ts
+++ b/resources/js/types/layout.ts
@@ -23,6 +23,8 @@ export interface LayoutBlock {
   rotation?: number
   position_x: number
   position_y: number
+  colspan?: number
+  rowspan?: number
   rows?: Row[]
 }
 
@@ -38,6 +40,8 @@ export interface PropBlock {
   position_x: number
   position_y: number
   rotation?: number
+  colspan?: number
+  rowspan?: number
   rows?: PropRow[]
 }
 
@@ -46,6 +50,8 @@ export interface PropStageBlock {
   name: string
   position_x: number
   position_y: number
+  colspan?: number
+  rowspan?: number
 }
 
 export interface PropMarkerBlock {
@@ -55,6 +61,8 @@ export interface PropMarkerBlock {
   position_x: number
   position_y: number
   rotation?: number
+  colspan?: number
+  rowspan?: number
 }
 
 export interface FormRow {
@@ -70,6 +78,8 @@ export interface FormBlock {
   position_x: number
   position_y: number
   rotation: number
+  colspan: number
+  rowspan: number
   rows: FormRow[]
 }
 
@@ -78,6 +88,8 @@ export interface FormStageBlock {
   name: string
   position_x: number
   position_y: number
+  colspan: number
+  rowspan: number
 }
 
 export interface FormMarkerBlock {
@@ -88,4 +100,6 @@ export interface FormMarkerBlock {
   position_y: number
   orientation?: Orientation
   rotation?: number
+  colspan: number
+  rowspan: number
 }

--- a/tests/Feature/Admin/RoomLayoutControllerTest.php
+++ b/tests/Feature/Admin/RoomLayoutControllerTest.php
@@ -190,6 +190,68 @@ class RoomLayoutControllerTest extends TestCase
     }
 
     /** @test */
+    public function layout_update_rejects_overlapping_blocks_across_collections()
+    {
+        $this->actingAs($this->admin);
+
+        $seatingBlock = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+        $stageBlock = Block::factory()->stage()->create(['room_id' => $this->room->id]);
+
+        $response = $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'stageBlocks' => [
+                ['id' => $stageBlock->id, 'name' => 'Stage', 'position_x' => 2, 'position_y' => 2],
+            ],
+            'blocks' => [
+                [
+                    'id' => $seatingBlock->id,
+                    'name' => 'Block',
+                    'position_x' => 2,
+                    'position_y' => 2,
+                    'rotation' => 0,
+                ],
+            ],
+        ]);
+
+        $response->assertSessionHasErrors(['stageBlocks.0.position_x', 'blocks.0.position_x']);
+    }
+
+    /** @test */
+    public function layout_update_rejects_overlapping_blocks_within_a_collection()
+    {
+        $this->actingAs($this->admin);
+
+        $blockA = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+        $blockB = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+
+        $response = $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'blocks' => [
+                ['id' => $blockA->id, 'name' => 'Block A', 'position_x' => 3, 'position_y' => 3, 'rotation' => 0, 'colspan' => 2, 'rowspan' => 2],
+                ['id' => $blockB->id, 'name' => 'Block B', 'position_x' => 4, 'position_y' => 4, 'rotation' => 0],
+            ],
+        ]);
+
+        $response->assertSessionHasErrors(['blocks.0.position_x', 'blocks.1.position_x']);
+    }
+
+    /** @test */
+    public function layout_update_allows_adjacent_non_overlapping_blocks()
+    {
+        $this->actingAs($this->admin);
+
+        $blockA = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+        $blockB = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+
+        $response = $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'blocks' => [
+                ['id' => $blockA->id, 'name' => 'Block A', 'position_x' => 0, 'position_y' => 0, 'rotation' => 0],
+                ['id' => $blockB->id, 'name' => 'Block B', 'position_x' => 1, 'position_y' => 0, 'rotation' => 0],
+            ],
+        ]);
+
+        $response->assertSessionDoesntHaveErrors();
+    }
+
+    /** @test */
     public function layout_update_creates_block_from_temp_id_and_returns_mapping()
     {
         $this->actingAs($this->admin);

--- a/tests/Feature/Admin/RoomLayoutControllerTest.php
+++ b/tests/Feature/Admin/RoomLayoutControllerTest.php
@@ -869,4 +869,76 @@ class RoomLayoutControllerTest extends TestCase
         $response = $this->delete(route('admin.rooms.blocks.delete', ['room' => $this->room->id, 'block' => $block->id]));
         $response->assertForbidden();
     }
+
+    /** @test */
+    public function layout_update_persists_colspan_and_rowspan()
+    {
+        $this->actingAs($this->admin);
+
+        $seatingBlock = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+
+        $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'blocks' => [
+                [
+                    'id' => $seatingBlock->id,
+                    'name' => 'Block A',
+                    'position_x' => 2,
+                    'position_y' => 2,
+                    'rotation' => 0,
+                    'colspan' => 4,
+                    'rowspan' => 2,
+                    'rowsData' => [['rowNumber' => 1, 'seatCount' => 5, 'isCustom' => false]],
+                ],
+            ],
+        ])->assertSessionHas('success');
+
+        $this->assertDatabaseHas('blocks', ['id' => $seatingBlock->id, 'colspan' => 4, 'rowspan' => 2]);
+    }
+
+    /** @test */
+    public function layout_update_defaults_colspan_and_rowspan_to_one()
+    {
+        $this->actingAs($this->admin);
+
+        $seatingBlock = Block::factory()->seating()->create(['room_id' => $this->room->id, 'colspan' => 3, 'rowspan' => 3]);
+
+        $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'blocks' => [
+                [
+                    'id' => $seatingBlock->id,
+                    'name' => 'Block A',
+                    'position_x' => 0,
+                    'position_y' => 0,
+                    'rotation' => 0,
+                    'rowsData' => [['rowNumber' => 1, 'seatCount' => 5, 'isCustom' => false]],
+                ],
+            ],
+        ])->assertRedirect();
+
+        $this->assertDatabaseHas('blocks', ['id' => $seatingBlock->id, 'colspan' => 1, 'rowspan' => 1]);
+    }
+
+    /** @test */
+    public function layout_update_validates_span_range()
+    {
+        $this->actingAs($this->admin);
+
+        $seatingBlock = Block::factory()->seating()->create(['room_id' => $this->room->id]);
+
+        $response = $this->put(route('admin.rooms.layout.update', $this->room->id), [
+            'blocks' => [
+                [
+                    'id' => $seatingBlock->id,
+                    'name' => 'Block A',
+                    'position_x' => 0,
+                    'position_y' => 0,
+                    'rotation' => 0,
+                    'colspan' => 0,
+                    'rowspan' => 99,
+                ],
+            ],
+        ]);
+
+        $response->assertSessionHasErrors(['blocks.0.colspan', 'blocks.0.rowspan']);
+    }
 }

--- a/tests/Feature/Migrations/ColspanRowspanMigrationTest.php
+++ b/tests/Feature/Migrations/ColspanRowspanMigrationTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature\Migrations;
+
+use App\Models\Room;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use ReflectionClass;
+use Tests\TestCase;
+
+class ColspanRowspanMigrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function migration(): object
+    {
+        return require database_path('migrations/2026_07_26_113314_add_colspan_and_rowspan_to_blocks_table.php');
+    }
+
+    private function callPrivate(object $object, string $method, array $args = [])
+    {
+        $method = (new ReflectionClass($object))->getMethod($method);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $args);
+    }
+
+    private function insertBlock(int $roomId, array $overrides = []): int
+    {
+        return DB::table('blocks')->insertGetId(array_merge([
+            'room_id' => $roomId,
+            'name' => 'A',
+            'type' => 'seating',
+            'position_x' => 0,
+            'position_y' => 0,
+            'rotation' => 0,
+            'colspan' => 1,
+            'rowspan' => 1,
+            'order' => 0,
+        ], $overrides));
+    }
+
+    /** @test */
+    public function merge_joins_adjacent_stage_and_comment_blocks_but_leaves_seating_alone(): void
+    {
+        $room = Room::factory()->create();
+
+        // Two adjacent stage blocks, side by side -> should merge into one with colspan 2.
+        $stageId = $this->insertBlock($room->id, ['name' => 'Stage', 'type' => 'stage', 'position_x' => 0, 'position_y' => 0]);
+        $this->insertBlock($room->id, ['name' => 'Stage', 'type' => 'stage', 'position_x' => 1, 'position_y' => 0]);
+
+        // Two adjacent comment blocks, stacked -> should merge into one with rowspan 2.
+        $commentId = $this->insertBlock($room->id, ['name' => 'Note', 'type' => 'comment', 'position_x' => 5, 'position_y' => 5]);
+        $this->insertBlock($room->id, ['name' => 'Note', 'type' => 'comment', 'position_x' => 5, 'position_y' => 6]);
+
+        // A seating block sitting right next to another seating block - merge must never
+        // touch seating, so this must stay as two separate, unspanned blocks.
+        $seatingId = $this->insertBlock($room->id, ['name' => 'B1', 'type' => 'seating', 'position_x' => 9, 'position_y' => 9]);
+        $this->insertBlock($room->id, ['name' => 'B1', 'type' => 'seating', 'position_x' => 10, 'position_y' => 9]);
+
+        $this->callPrivate($this->migration(), 'mergeAdjacentBlocks');
+
+        $this->assertDatabaseHas('blocks', ['id' => $stageId, 'colspan' => 2, 'rowspan' => 1]);
+        $this->assertDatabaseHas('blocks', ['id' => $commentId, 'colspan' => 1, 'rowspan' => 2]);
+        $this->assertSame(2, DB::table('blocks')->where('id', $seatingId)->orWhere('name', 'B1')->count());
+        $this->assertSame(4, DB::table('blocks')->where('room_id', $room->id)->count());
+    }
+
+    /** @test */
+    public function rollback_splits_stage_and_comment_blocks_but_not_a_spanned_seating_block(): void
+    {
+        $room = Room::factory()->create();
+
+        $stageId = $this->insertBlock($room->id, [
+            'name' => 'Stage', 'type' => 'stage', 'position_x' => 0, 'position_y' => 0, 'colspan' => 2,
+        ]);
+        $commentId = $this->insertBlock($room->id, [
+            'name' => 'Note', 'type' => 'comment', 'position_x' => 5, 'position_y' => 5, 'rowspan' => 2,
+        ]);
+        $seatingId = $this->insertBlock($room->id, [
+            'name' => 'B1', 'type' => 'seating', 'position_x' => 9, 'position_y' => 9, 'colspan' => 2,
+        ]);
+
+        $this->callPrivate($this->migration(), 'splitSpannedBlocks');
+
+        $this->assertDatabaseHas('blocks', ['id' => $stageId, 'position_x' => 0, 'position_y' => 0, 'colspan' => 2]);
+        $this->assertDatabaseHas('blocks', ['name' => 'Stage', 'type' => 'stage', 'position_x' => 1, 'position_y' => 0]);
+        $this->assertDatabaseHas('blocks', ['id' => $commentId, 'position_x' => 5, 'position_y' => 5, 'rowspan' => 2]);
+        $this->assertDatabaseHas('blocks', ['name' => 'Note', 'type' => 'comment', 'position_x' => 5, 'position_y' => 6]);
+
+        // Left untouched: splitting would clone an empty seating block next to the real one,
+        // duplicating it without any of its actual rows/seats.
+        $this->assertDatabaseHas('blocks', ['id' => $seatingId, 'position_x' => 9, 'position_y' => 9, 'colspan' => 2]);
+        $this->assertSame(1, DB::table('blocks')->where('name', 'B1')->count());
+
+        $this->assertSame(5, DB::table('blocks')->where('room_id', $room->id)->count());
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -121,5 +121,8 @@
         "resources/js/**/*.d.ts",
         "resources/js/**/*.tsx",
         "resources/js/**/*.vue"
+    ],
+    "exclude": [
+        "resources/js/**/*.check.ts"
     ]
 }


### PR DESCRIPTION
<img width="996" height="418" alt="Screenshot 2026-07-27 at 17 45 05" src="https://github.com/user-attachments/assets/7e6552d1-66f7-4fd3-8d3b-73b7622a41bb" />
<img width="672" height="370" alt="Screenshot 2026-07-27 at 18 04 19" src="https://github.com/user-attachments/assets/4074a594-3498-4086-8796-31125cf58b70" />
<img width="651" height="308" alt="Screenshot 2026-07-27 at 18 06 14" src="https://github.com/user-attachments/assets/e8e5f8de-27e7-4b10-b931-f0fe432ddfba" />

Convert previous methods of doing colspan/rowspan into colspan/rowspan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-cell `colspan`/`rowspan` support for stage blocks, seating blocks, and comment markers, including generated seating/SVG/PDF outputs.
  * Updated the room layout editor to use span-aware placement with improved spanning controls and layout rendering.

* **Bug Fixes**
  * Added/strengthened server-side validation and defaulting of missing spans to `1`.
  * Improved span geometry so collisions, bounds, and comment marker sizing/placement behave consistently.

* **Tests**
  * Added tests for span persistence, defaulting, validation, and migration rollback/splitting behavior.
  * Added lightweight regression checks for grid/layout utilities and input coercion.

* **Chores**
  * Improved input component behavior with controlled updates, trimming/number coercion, and IME-safe commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->