### PR TITLE
import fails due to stale cache

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -7,6 +7,7 @@ use App\Http\Middleware\Authenticate;
 use App\Http\Middleware\EncryptCookies;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\PreventRequestsDuringMaintenance;
+use App\Http\Middleware\PreventStaleCache;
 use App\Http\Middleware\RedirectIfAuthenticated;
 use App\Http\Middleware\TrimStrings;
 use App\Http\Middleware\TrustProxies;
@@ -62,6 +63,7 @@ class Kernel extends HttpKernel
             VerifyCsrfToken::class,
             SubstituteBindings::class,
             HandleInertiaRequests::class,
+            PreventStaleCache::class,
         ],
 
         'api' => [

--- a/app/Http/Middleware/PreventStaleCache.php
+++ b/app/Http/Middleware/PreventStaleCache.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class PreventStaleCache
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        // Prevent stale bfcache/disk-cache pages from serving outdated session state.
+        $response->headers->set('Cache-Control', 'no-store, private');
+
+        return $response;
+    }
+}

--- a/tests/Feature/PreventStaleCacheTest.php
+++ b/tests/Feature/PreventStaleCacheTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class PreventStaleCacheTest extends TestCase
+{
+    /** @test */
+    public function web_responses_include_no_store_cache_control_header()
+    {
+        $this->get(route('login'))
+            ->assertHeader('Cache-Control', 'no-store, private');
+    }
+}


### PR DESCRIPTION
Adding no-store cache headers to hole app to avoid stale cache


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web page caching behavior to prevent outdated session information from being displayed.
  * Ensured responses are treated as private and not stored for reuse by browser or disk caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->