### PR TITLE
Provision php.ini in production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,12 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 ######################################################
+# PHP config - the frankenphp base image ships with NO php.ini at all, so start
+# from the official production template, then layer our own overrides on top.
+######################################################
+RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+COPY php.ini "$PHP_INI_DIR/conf.d/99-app.ini"
+######################################################
 # Configure Credentials & Hosts for external Git (optional)
 ######################################################
 COPY composer.json composer.lock /app/


### PR DESCRIPTION
The frankenphp base image ships with no php.ini by default, so the repo's memory_limit override was never applied in production.

https://frankenphp.dev/docs/config/  => " (no php.ini is provided by default)"