### PR TITLE
Moving import data out of the session

### DIFF
--- a/app/Booking/GlobalImportSession.php
+++ b/app/Booking/GlobalImportSession.php
@@ -13,12 +13,13 @@ class GlobalImportSession
         private ImportProposalBuilder $proposals,
         private ImportBookingWriter $writer,
         private SeatAssigner $seats,
+        private ImportSessionStore $importSession,
     ) {}
 
     /** Drop every session key that tracks an in-progress global import. */
     private function forgetQueue(): void
     {
-        session()->forget(['global_import_queue', 'global_import_total', 'global_import_done', 'staged_import']);
+        $this->importSession->forget(['global_import_queue', 'global_import_total', 'global_import_done', 'staged_import']);
     }
 
     /**
@@ -28,15 +29,15 @@ class GlobalImportSession
      */
     public function advanceQueue(int $justConfirmedEventId, string $summary)
     {
-        $queue = session()->get('global_import_queue');
+        $queue = $this->importSession->get('global_import_queue');
 
         if ($queue === null) {
             return redirect()->route('admin.events.show', $justConfirmedEventId)
                 ->with('success', $summary);
         }
 
-        $total = session()->get('global_import_total', count($queue) + 1);
-        $done = session()->get('global_import_done', 1);
+        $total = $this->importSession->get('global_import_total', count($queue) + 1);
+        $done = $this->importSession->get('global_import_done', 1);
 
         if (empty($queue)) {
             // Whole queue confirmed - write every staged event's bookings atomically.
@@ -62,9 +63,9 @@ class GlobalImportSession
                 ->with('warning', "The import was cancelled and nothing was booked. Stopped at '{$nextEvent->name}': {$result['error']}");
         }
 
-        session()->put("import_proposal:{$nextEvent->id}", $result['guests']);
-        session()->put('global_import_queue', $queue);
-        session()->put('global_import_done', $done + 1);
+        $this->importSession->put("import_proposal:{$nextEvent->id}", $result['guests']);
+        $this->importSession->put('global_import_queue', $queue);
+        $this->importSession->put('global_import_done', $done + 1);
 
         return redirect()->route('admin.events.import-bookings.preview', $nextEvent->id)
             ->with('success', "{$summary} Continuing with '{$nextEvent->name}' (".($done + 1)." of {$total}).");
@@ -78,7 +79,7 @@ class GlobalImportSession
      */
     private function flushStaged(int $total)
     {
-        $staged = session()->get('staged_import', []);
+        $staged = $this->importSession->get('staged_import', []);
 
         if (empty($staged)) {
             $this->forgetQueue();

--- a/app/Booking/ImportSessionStore.php
+++ b/app/Booking/ImportSessionStore.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Booking;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+/**
+ * Backs the CSV-import propose/preview/confirm flow's server-side state (proposals, the
+ * global-import queue, staged bookings) with the cache store, keyed by a token in the
+ * session. This keeps the session payload small (just the token) while scoping the
+ * cached state to the current admin, so concurrent imports never collide.
+ *
+ * The token, not session()->getId(), is the cache namespace: the session id isn't
+ * guaranteed stable across login/logout, but a value round-tripped through
+ * session()->put()/get() is.
+ */
+class ImportSessionStore
+{
+    private function token(): string
+    {
+        $token = session()->get('import_session_token');
+
+        if ($token === null) {
+            $token = (string) Str::uuid();
+            session()->put('import_session_token', $token);
+        }
+
+        return $token;
+    }
+
+    private function key(string $key): string
+    {
+        return 'import:'.$this->token().':'.$key;
+    }
+
+    public function put(string $key, mixed $value): void
+    {
+        Cache::put($this->key($key), $value, now()->addMinutes((int) config('session.lifetime')));
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return Cache::get($this->key($key), $default);
+    }
+
+    public function has(string $key): bool
+    {
+        return Cache::has($this->key($key));
+    }
+
+    public function forget(string|array $keys): void
+    {
+        foreach ((array) $keys as $key) {
+            Cache::forget($this->key($key));
+        }
+    }
+}

--- a/app/Booking/ImportSessionStore.php
+++ b/app/Booking/ImportSessionStore.php
@@ -39,9 +39,23 @@ class ImportSessionStore
         Cache::put($this->key($key), $value, now()->addMinutes((int) config('session.lifetime')));
     }
 
+    /**
+     * Reads renew the entry's expiry (sliding window) so a key merely being viewed - e.g. a
+     * preview page left open without submitting - doesn't expire out from under an admin who
+     * is still within their session lifetime.
+     */
     public function get(string $key, mixed $default = null): mixed
     {
-        return Cache::get($this->key($key), $default);
+        $fullKey = $this->key($key);
+        $value = Cache::get($fullKey);
+
+        if ($value === null) {
+            return $default;
+        }
+
+        Cache::put($fullKey, $value, now()->addMinutes((int) config('session.lifetime')));
+
+        return $value;
     }
 
     public function has(string $key): bool

--- a/app/Http/Controllers/Admin/ConfirmImportController.php
+++ b/app/Http/Controllers/Admin/ConfirmImportController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Booking\GlobalImportSession;
 use App\Booking\ImportBookingWriter;
+use App\Booking\ImportSessionStore;
 use App\Booking\SeatAssigner;
 use App\Http\Controllers\Controller;
 use App\Models\Booking;
@@ -14,7 +15,7 @@ use Illuminate\Support\Facades\DB;
 
 class ConfirmImportController extends Controller
 {
-    public function __invoke(Request $request, $id, ImportBookingWriter $writer, SeatAssigner $seats, GlobalImportSession $global)
+    public function __invoke(Request $request, $id, ImportBookingWriter $writer, SeatAssigner $seats, GlobalImportSession $global, ImportSessionStore $importSession)
     {
         $data = $request->validate([
             'guests' => 'required|array|min:1',
@@ -34,7 +35,7 @@ class ConfirmImportController extends Controller
         // Gate against booking fewer seats than the CSV requested for any guest. The
         // required minimum comes from the session's canonical proposal (not the client's
         // payload) so it can't be tampered with by editing the posted request.
-        $sessionProposal = session()->get("import_proposal:{$id}");
+        $sessionProposal = $importSession->get("import_proposal:{$id}");
 
         // Reject confirmations without a pending proposal - otherwise a client that has lost
         // (or never had) session state can POST directly and skip the whole quota/alignment
@@ -175,7 +176,7 @@ class ConfirmImportController extends Controller
         // instead STAGES each confirmed event in the session and writes everything in one
         // atomic transaction only when the whole queue is done (see GlobalImportSession) - so
         // abandoning a global import half-way leaves nothing booked at all.
-        $isGlobal = session()->has('global_import_queue');
+        $isGlobal = $importSession->has('global_import_queue');
         $createdByName = auth()->user()->name;
 
         DB::transaction(function () use ($id, $bookableGuests, $allSeatIds, $isGlobal, $writer, $pendingRenames, $removedBookingIds, $createdByName, &$conflictSeatIds) {
@@ -200,7 +201,7 @@ class ConfirmImportController extends Controller
         });
 
         if (empty($conflictSeatIds)) {
-            session()->forget("import_proposal:{$id}");
+            $importSession->forget("import_proposal:{$id}");
 
             $alreadyBookedNote = '';
             if ($alreadyBookedCount > 0) {
@@ -224,14 +225,14 @@ class ConfirmImportController extends Controller
                 // - stage the rename/delete instructions alongside the bookable guests so
                 // GlobalImportSession::flushStaged() can apply them atomically with everyone
                 // else's bookings (see the transaction above for the non-global equivalent).
-                $staged = session()->get('staged_import', []);
+                $staged = $importSession->get('staged_import', []);
                 $staged[$id] = [
                     'guests' => $bookableGuests,
                     'renames' => $pendingRenames,
                     'deletes' => $removedBookingIds,
                     'created_by_name' => $createdByName,
                 ];
-                session()->put('staged_import', $staged);
+                $importSession->put('staged_import', $staged);
 
                 $summary = 'Staged '.count($allSeatIds).' booking(s) for '.count($bookableGuests).' guest(s).'.$alreadyBookedNote;
             } else {
@@ -289,7 +290,7 @@ class ConfirmImportController extends Controller
         }
         unset($guest);
 
-        session()->put("import_proposal:{$id}", $guests);
+        $importSession->put("import_proposal:{$id}", $guests);
 
         $names = implode(', ', $affectedNames);
 

--- a/app/Http/Controllers/Admin/GlobalProposeImportController.php
+++ b/app/Http/Controllers/Admin/GlobalProposeImportController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Booking\EventMatcher;
 use App\Booking\ImportCsvParser;
 use App\Booking\ImportProposalBuilder;
+use App\Booking\ImportSessionStore;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 
@@ -17,7 +18,7 @@ use Illuminate\Http\Request;
  */
 class GlobalProposeImportController extends Controller
 {
-    public function __invoke(Request $request, ImportCsvParser $parser, EventMatcher $matcher, ImportProposalBuilder $proposals)
+    public function __invoke(Request $request, ImportCsvParser $parser, EventMatcher $matcher, ImportProposalBuilder $proposals, ImportSessionStore $importSession)
     {
         $request->validate([
             'file' => 'required|file|mimes:csv,txt|max:2048',
@@ -54,15 +55,15 @@ class GlobalProposeImportController extends Controller
             return back()->with('error', $result['error']);
         }
 
-        session()->put("import_proposal:{$first['event']->id}", $result['guests']);
-        session()->put('global_import_queue', array_map(
+        $importSession->put("import_proposal:{$first['event']->id}", $result['guests']);
+        $importSession->put('global_import_queue', array_map(
             fn ($entry) => ['event_id' => $entry['event']->id, 'rows' => $entry['rows']],
             $queue
         ));
-        session()->put('global_import_total', count($queue) + 1);
-        session()->put('global_import_done', 1);
+        $importSession->put('global_import_total', count($queue) + 1);
+        $importSession->put('global_import_done', 1);
         // Start staging from scratch - drop anything left over from an abandoned prior run.
-        session()->forget('staged_import');
+        $importSession->forget('staged_import');
 
         return redirect()->route('admin.events.import-bookings.preview', $first['event']->id);
     }

--- a/app/Http/Controllers/Admin/ImportPreviewController.php
+++ b/app/Http/Controllers/Admin/ImportPreviewController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Booking\ImportSessionStore;
 use App\Booking\RoomLayoutLoader;
 use App\Http\Controllers\Controller;
 use App\Models\Event;
@@ -9,13 +10,13 @@ use Inertia\Inertia;
 
 class ImportPreviewController extends Controller
 {
-    public function __invoke($id, RoomLayoutLoader $layout)
+    public function __invoke($id, RoomLayoutLoader $layout, ImportSessionStore $importSession)
     {
         $event = Event::select('id', 'name', 'room_id')
             ->with('room:id,name,stage_x,stage_y')
             ->findOrFail($id);
 
-        $proposal = session()->get("import_proposal:{$id}");
+        $proposal = $importSession->get("import_proposal:{$id}");
 
         if (! $proposal) {
             return redirect()->route('admin.events.show', $id)
@@ -27,10 +28,10 @@ class ImportPreviewController extends Controller
         // When this preview is part of a cross-event "global import", surface how far along
         // the queue we are so the admin can see how many events are left to click through.
         $progress = null;
-        if (session()->has('global_import_total')) {
+        if ($importSession->has('global_import_total')) {
             $progress = [
-                'done' => session()->get('global_import_done', 1),
-                'total' => session()->get('global_import_total'),
+                'done' => $importSession->get('global_import_done', 1),
+                'total' => $importSession->get('global_import_total'),
             ];
         }
 

--- a/app/Http/Controllers/Admin/ImportPreviewController.php
+++ b/app/Http/Controllers/Admin/ImportPreviewController.php
@@ -29,6 +29,12 @@ class ImportPreviewController extends Controller
         // the queue we are so the admin can see how many events are left to click through.
         $progress = null;
         if ($importSession->has('global_import_total')) {
+            // Touch every workflow key for this global import, not just the ones this page
+            // happens to display - otherwise the queue/staged bookings could expire from the
+            // cache while the admin is still reading a later step's preview.
+            $importSession->get('global_import_queue');
+            $importSession->get('staged_import');
+
             $progress = [
                 'done' => $importSession->get('global_import_done', 1),
                 'total' => $importSession->get('global_import_total'),

--- a/app/Http/Controllers/Admin/ProposeImportController.php
+++ b/app/Http/Controllers/Admin/ProposeImportController.php
@@ -5,13 +5,14 @@ namespace App\Http\Controllers\Admin;
 use App\Booking\EventMatcher;
 use App\Booking\ImportCsvParser;
 use App\Booking\ImportProposalBuilder;
+use App\Booking\ImportSessionStore;
 use App\Http\Controllers\Controller;
 use App\Models\Event;
 use Illuminate\Http\Request;
 
 class ProposeImportController extends Controller
 {
-    public function __invoke(Request $request, $id, ImportCsvParser $parser, ImportProposalBuilder $proposals, EventMatcher $matcher)
+    public function __invoke(Request $request, $id, ImportCsvParser $parser, ImportProposalBuilder $proposals, EventMatcher $matcher, ImportSessionStore $importSession)
     {
         $request->validate([
             'file' => 'required|file|mimes:csv,txt|max:2048',
@@ -54,9 +55,9 @@ class ProposeImportController extends Controller
         // A single-event import writes immediately on confirm, so make sure no leftover
         // global-import state from an abandoned cross-event run is still around - otherwise
         // confirmImport would mistake this for a global import and stage instead of book.
-        session()->forget(['global_import_queue', 'global_import_total', 'global_import_done', 'staged_import']);
+        $importSession->forget(['global_import_queue', 'global_import_total', 'global_import_done', 'staged_import']);
 
-        session()->put("import_proposal:{$id}", $result['guests']);
+        $importSession->put("import_proposal:{$id}", $result['guests']);
 
         $redirect = redirect()->route('admin.events.import-bookings.preview', $id);
 

--- a/tests/Feature/Admin/BookingImportTest.php
+++ b/tests/Feature/Admin/BookingImportTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Admin;
 
+use App\Booking\ImportSessionStore;
 use App\Models\Block;
 use App\Models\Booking;
 use App\Models\Event;
@@ -1430,7 +1431,7 @@ class BookingImportTest extends TestCase
             ->assertRedirect()
             ->assertSessionHas('error');
 
-        $this->assertNull(session()->get("import_proposal:{$event->id}"));
+        $this->assertNull(app(ImportSessionStore::class)->get("import_proposal:{$event->id}"));
     }
 
     /** @test */
@@ -1488,7 +1489,7 @@ class BookingImportTest extends TestCase
 
         $response->assertRedirect();
         $response->assertSessionHas('error', fn ($error) => str_contains($error, 'Number of Seats'));
-        $response->assertSessionMissing("import_proposal:{$event->id}");
+        $this->assertNull(app(ImportSessionStore::class)->get("import_proposal:{$event->id}"));
         $this->assertDatabaseCount('bookings', 0);
     }
 
@@ -1512,7 +1513,7 @@ class BookingImportTest extends TestCase
 
         $response->assertRedirect();
         $response->assertSessionHas('error', fn ($error) => str_contains($error, 'Not enough available seats'));
-        $response->assertSessionMissing("import_proposal:{$event->id}");
+        $this->assertNull(app(ImportSessionStore::class)->get("import_proposal:{$event->id}"));
         $this->assertDatabaseCount('bookings', 0);
     }
 
@@ -1712,10 +1713,10 @@ class BookingImportTest extends TestCase
         $response->assertRedirect();
         $response->assertSessionHas('error');
         $this->assertDatabaseCount('bookings', 0);
-        $this->assertNull(session('global_import_queue'));
+        $this->assertNull(app(ImportSessionStore::class)->get('global_import_queue'));
         // Event One's own row was fine, but the later bad row aborts the whole upload upfront -
         // the admin must never see Event One's proposal staged.
-        $response->assertSessionMissing("import_proposal:{$eventOne->id}");
+        $this->assertNull(app(ImportSessionStore::class)->get("import_proposal:{$eventOne->id}"));
     }
 
     /** @test */
@@ -2163,7 +2164,7 @@ class BookingImportTest extends TestCase
 
         $response->assertRedirect();
         $response->assertSessionHas('error', fn ($error) => str_contains($error, 'Not enough available seats'));
-        $response->assertSessionMissing("import_proposal:{$event->id}");
+        $this->assertNull(app(ImportSessionStore::class)->get("import_proposal:{$event->id}"));
         $this->assertDatabaseCount('bookings', 0);
     }
 

--- a/tests/Feature/Admin/BookingImportTest.php
+++ b/tests/Feature/Admin/BookingImportTest.php
@@ -1612,6 +1612,76 @@ class BookingImportTest extends TestCase
     }
 
     /** @test */
+    public function import_state_survives_a_slow_admin_who_only_views_pages_past_one_cache_lifetime()
+    {
+        $admin = $this->actingAsAdmin();
+        [$room1, , , , $seat1A1] = $this->createRoomWithSeats();
+        [$room2, , , , $seat2A1] = $this->createRoomWithSeats();
+
+        $event1 = Event::create([
+            'name' => 'Event One',
+            'room_id' => $room1->id,
+            'starts_at' => Carbon::now()->addDays(1),
+            'reservation_ends_at' => Carbon::now()->addHours(1),
+            'max_tickets' => 50,
+        ]);
+        $event2 = Event::create([
+            'name' => 'Event Two',
+            'room_id' => $room2->id,
+            'starts_at' => Carbon::now()->addDays(1),
+            'reservation_ends_at' => Carbon::now()->addHours(1),
+            'max_tickets' => 50,
+        ]);
+
+        $csv = "Event,Guest Name,Comment,Block,Row,Seat\n".
+            "Event One,Alice,,A,1,1\n".
+            "Event Two,Bob,,A,1,1\n";
+
+        $this->post(route('admin.import-bookings.propose'), [
+            'file' => $this->csvFile($csv),
+        ])->assertRedirect(route('admin.events.import-bookings.preview', $event1->id));
+
+        // Admin leaves the first preview page open, checking back on it every so often
+        // without ever submitting - each view is a read-only request (no ->put calls). The
+        // gaps between views are individually well under one cache lifetime, but they add up
+        // to more than a full lifetime overall: without renewing the TTL on read, the staged
+        // proposal/queue would expire partway through even though the admin was still active.
+        $lifetimeMinutes = (int) config('session.lifetime');
+        $this->travel($lifetimeMinutes - 10)->minutes();
+        $this->previewProps($event1->id);
+        $this->travel($lifetimeMinutes - 10)->minutes();
+        $props = $this->previewProps($event1->id);
+        $this->assertCount(1, $props['proposal']);
+        $this->assertEquals('Alice', $props['proposal'][0]['guest_name']);
+
+        // Confirm event 1, then again keep checking event 2's preview well past a combined
+        // lifetime before confirming - the queue/total/staged data must still be there.
+        $this->post(route('admin.events.import-bookings.confirm', $event1->id), [
+            'guests' => [
+                ['guest_name' => 'Alice', 'comment' => null, 'seat_ids' => [$seat1A1->id]],
+            ],
+        ])->assertRedirect(route('admin.events.import-bookings.preview', $event2->id));
+
+        $this->travel($lifetimeMinutes - 10)->minutes();
+        $this->previewProps($event2->id);
+        $this->travel($lifetimeMinutes - 10)->minutes();
+        $props = $this->previewProps($event2->id);
+        $this->assertCount(1, $props['proposal']);
+        $this->assertEquals('Bob', $props['proposal'][0]['guest_name']);
+        $this->assertEquals(['done' => 2, 'total' => 2], $props['progress']);
+
+        $this->post(route('admin.events.import-bookings.confirm', $event2->id), [
+            'guests' => [
+                ['guest_name' => 'Bob', 'comment' => null, 'seat_ids' => [$seat2A1->id]],
+            ],
+        ])->assertRedirect(route('admin.events.index'));
+
+        $this->assertDatabaseHas('bookings', ['event_id' => $event1->id, 'name' => 'Alice', 'created_by_name' => $admin->name]);
+        $this->assertDatabaseHas('bookings', ['event_id' => $event2->id, 'name' => 'Bob', 'created_by_name' => $admin->name]);
+        $this->assertDatabaseCount('bookings', 2);
+    }
+
+    /** @test */
     public function abandoning_a_global_import_midway_books_nothing()
     {
         $this->actingAsAdmin();


### PR DESCRIPTION
The bulk-import propose→preview→confirm flow stored the whole parsed guest list in the session. Large CSVs blew past nginx's header-size limit → 502.

Fix: added ImportSessionStore — keeps only a small UUID token in the session, moves the actual import data (proposals, global-import queue, staged bookings) into the cache store instead. Works regardless of session driver, so it doesn't depend on ops fixing the cookie misconfiguration (which is still worth fixing separately, just not blocking).