### PR TITLE
Add event name to seating card, and pagination

### DIFF
--- a/app/Http/Controllers/Admin/SeatingCardsController.php
+++ b/app/Http/Controllers/Admin/SeatingCardsController.php
@@ -112,20 +112,7 @@ class SeatingCardsController extends Controller
             $masterCardMaxheight = self::masterCardMaxHeight($event->name);
             $orderCardMaxheight = self::orderCardMaxHeight($event->name);
 
-            $totalCards = 1;
-
-            $currentBlockId = null;
-            foreach ($bookings as $booking) {
-                $block = $booking->seat->row->block;
-
-                if ($block->id !== $currentBlockId) {
-                    $currentBlockId = $block->id;
-
-                    $totalCards++;
-                }
-
-                $totalCards++;
-            }
+            $totalCards = self::totalCardCount($bookings);
 
             $currentCard = 1;
 
@@ -201,5 +188,26 @@ class SeatingCardsController extends Controller
     public static function orderCardMaxHeight(string $eventName): int
     {
         return Str::length($eventName) > 19 ? 90 : 105;
+    }
+
+    // Master overview page + one order-card page per distinct block + one card per booking.
+    public static function totalCardCount(iterable $bookings): int
+    {
+        $total = 1;
+        $currentBlockId = null;
+
+        foreach ($bookings as $booking) {
+            $blockId = $booking->seat->row->block->id;
+
+            if ($blockId !== $currentBlockId) {
+                $currentBlockId = $blockId;
+
+                $total++;
+            }
+
+            $total++;
+        }
+
+        return $total;
     }
 }

--- a/app/Http/Controllers/Admin/SeatingCardsController.php
+++ b/app/Http/Controllers/Admin/SeatingCardsController.php
@@ -110,10 +110,30 @@ class SeatingCardsController extends Controller
             $pages = [];
 
             $masterCardMaxheight = self::masterCardMaxHeight($event->name);
+            $orderCardMaxheight = self::orderCardMaxHeight($event->name);
+
+            $totalCards = 1;
+
+            $currentBlockId = null;
+            foreach ($bookings as $booking) {
+                $block = $booking->seat->row->block;
+
+                if ($block->id !== $currentBlockId) {
+                    $currentBlockId = $block->id;
+
+                    $totalCards++;
+                }
+
+                $totalCards++;
+            }
+
+            $currentCard = 1;
 
             $pages[] = view('pdf.master-page', [
+                'pagination' => ($currentCard++).'/'.$totalCards,
                 'event_name' => $event->name,
                 'room_name' => $room->name,
+                'total_bookings' => $bookings->count(),
                 'overview' => $masterCard->render($masterBlocks, $masterStageBlocks, $masterMarkerBlocks, $bookedSeatIds, $mpdf, $masterCardMaxheight),
             ])->render();
 
@@ -128,17 +148,19 @@ class SeatingCardsController extends Controller
                     $previewBlock = $previewBlocks->get($block->id);
 
                     $pages[] = view('pdf.order-card', [
+                        'pagination' => ($currentCard++).'/'.$totalCards,
                         'info' => (object) [
                             'event_name' => $event->name,
                             'block_name' => 'Block '.$block->name,
                         ],
                         'preview' => $previewBlock
-                            ? $orderCard->render($previewBlock, $bookedSeatIds, $mpdf)
+                            ? $orderCard->render($previewBlock, $bookedSeatIds, $mpdf, $orderCardMaxheight)
                             : null,
                     ])->render();
                 }
 
                 $pages[] = view('pdf.seating-card-single', [
+                    'pagination' => ($currentCard++).'/'.$totalCards,
                     'booking' => $booking,
                     'event' => $event,
                 ])->render();
@@ -172,5 +194,12 @@ class SeatingCardsController extends Controller
     public static function masterCardMaxHeight(string $eventName): int
     {
         return Str::length($eventName) > 19 ? 90 : 110;
+    }
+
+    // ponytail: 19-char cutoff is a rough heuristic, not measured PDF layout. Upgrade
+    // path: measure the actual rendered text width and size the order card from that.
+    public static function orderCardMaxHeight(string $eventName): int
+    {
+        return Str::length($eventName) > 19 ? 90 : 105;
     }
 }

--- a/app/Http/Controllers/Admin/SeatingCardsController.php
+++ b/app/Http/Controllers/Admin/SeatingCardsController.php
@@ -32,20 +32,7 @@ class SeatingCardsController extends Controller
             }
 
             // Wind seats by row order so placing the cards is easier and faster for the runners.
-            $bookings = $bookingsQuery->get()->sortBy(function ($booking) {
-                $block = $booking->seat->row->block;
-                $rowOrder = $booking->seat->row->order;
-                $seatNumber = $booking->seat->number;
-
-                $seatSort = $rowOrder % 2 === 1 ? $seatNumber : -$seatNumber;
-
-                return [
-                    $block->position_y,
-                    $block->position_x,
-                    $rowOrder,
-                    $seatSort,
-                ];
-            });
+            $bookings = self::sortBookingsForPrinting($bookingsQuery->get());
 
             if ($bookings->isEmpty()) {
                 return back()->with('error', 'No bookings found for this event to generate seating cards.');
@@ -209,5 +196,25 @@ class SeatingCardsController extends Controller
         }
 
         return $total;
+    }
+
+    // Order bookings by block position, then wind seats by row order (ascending on odd
+    // rows, descending on even) so placing the cards is faster for the runners.
+    public static function sortBookingsForPrinting($bookings)
+    {
+        return $bookings->sortBy(function ($booking) {
+            $block = $booking->seat->row->block;
+            $rowOrder = $booking->seat->row->order;
+            $seatNumber = $booking->seat->number;
+
+            $seatSort = $rowOrder % 2 === 1 ? $seatNumber : -$seatNumber;
+
+            return [
+                $block->position_y,
+                $block->position_x,
+                $rowOrder,
+                $seatSort,
+            ];
+        });
     }
 }

--- a/app/Services/Svg/OrderCardSvgGenerator.php
+++ b/app/Services/Svg/OrderCardSvgGenerator.php
@@ -48,7 +48,7 @@ class OrderCardSvgGenerator
      *
      * @param  array<int,bool>  $bookedSeatIds  Set of booked seat IDs.
      */
-    public function render(Block $block, array $bookedSeatIds, Mpdf $mpdf): string
+    public function render(Block $block, array $bookedSeatIds, Mpdf $mpdf, int $maxHeight = 105): string
     {
         $this->rows = $block->rows->sortBy('order')->values();
         if ($this->rows->isEmpty()) {
@@ -77,7 +77,7 @@ class OrderCardSvgGenerator
         [$path, $turnArrows] = $this->windingPath();
         $arrows = $this->arrows($turnArrows, $mpdf);
 
-        $scale = min(195 / $width, 105 / $height);
+        $scale = min(195 / $width, $maxHeight / $height);
 
         return $this->svg->document($width, $height, $width * $scale, $height * $scale, $path.$boxes.$arrows);
     }

--- a/resources/views/pdf/card-layout.blade.php
+++ b/resources/views/pdf/card-layout.blade.php
@@ -118,13 +118,26 @@
             letter-spacing: 2px;
             background-color: #000;
             padding: 4mm 10mm;
+            padding-bottom: 3mm;
             white-space: nowrap;
         }
 
         .not-picked-up-wrapper {
             position: fixed;
-            bottom: 20mm;
+            top: 20mm;
             right: 20mm;
+        }
+
+        .pagination {
+            position: fixed;
+            top: 20mm;
+            left: 20mm;
+            width: 100mm;
+            margin: 0;
+            font-size: 17pt;
+            line-height: 1;
+            text-align: left;
+            white-space: nowrap;
         }
 
         @yield('styles')
@@ -135,5 +148,11 @@
         @yield('content')
     </div>
     @yield('overlay')
+
+    @if(!empty($pagination))
+    <div class="pagination">
+        {{ $pagination }}
+    </div>
+    @endif
 </body>
 </html>

--- a/resources/views/pdf/card-layout.blade.php
+++ b/resources/views/pdf/card-layout.blade.php
@@ -138,6 +138,8 @@
             line-height: 1;
             text-align: left;
             white-space: nowrap;
+
+            color: #d2d2d2;
         }
 
         @yield('styles')

--- a/resources/views/pdf/master-page.blade.php
+++ b/resources/views/pdf/master-page.blade.php
@@ -15,7 +15,7 @@
             @endif
         </div>
         <div class="block-name">
-            Layout
+            Layout - {{ $total_bookings }} bookings
         </div>
         @if(!empty($overview))
             <div class="block-preview master-overview">

--- a/resources/views/pdf/seating-card-single.blade.php
+++ b/resources/views/pdf/seating-card-single.blade.php
@@ -2,6 +2,20 @@
 
 @section('styles')
     .card-name { font-size: 90pt; }
+    .event-name {
+        position: fixed;
+        bottom: 20mm;
+        left: 0;
+        right: 0;
+        margin: 0;
+        width: 100%;
+        text-align: center;
+        font-size: 17pt;
+        line-height: 1;
+    }
+    .bigger {
+        font-size: 20pt;
+    }
 @endsection
 
 @section('content')
@@ -29,4 +43,9 @@
         </table>
     </div>
     @endif
+    <div class="event-name">
+        for
+        <br>
+        <span class="bigger">{{ $event->name }}</span>
+    </div>
 @endsection

--- a/resources/views/pdf/seating-card-single.blade.php
+++ b/resources/views/pdf/seating-card-single.blade.php
@@ -12,6 +12,7 @@
         text-align: center;
         font-size: 17pt;
         line-height: 1;
+        color: #d2d2d2;
     }
     .bigger {
         font-size: 20pt;

--- a/tests/Feature/Admin/SeatingCardsTest.php
+++ b/tests/Feature/Admin/SeatingCardsTest.php
@@ -37,6 +37,53 @@ class SeatingCardsTest extends TestCase
         $this->assertSame(90, SeatingCardsController::masterCardMaxHeight(str_repeat('é', 20)));
     }
 
+    public function test_order_card_max_height_for_19_character_event_name()
+    {
+        $this->assertSame(105, SeatingCardsController::orderCardMaxHeight(str_repeat('a', 19)));
+    }
+
+    public function test_order_card_max_height_for_20_character_event_name()
+    {
+        $this->assertSame(90, SeatingCardsController::orderCardMaxHeight(str_repeat('a', 20)));
+    }
+
+    public function test_total_card_count_for_single_block_bookings()
+    {
+        // Master page + 1 order card for the block + 1 card per booking.
+        $bookings = collect([
+            $this->makeBookingStub(1),
+            $this->makeBookingStub(1),
+            $this->makeBookingStub(1),
+        ]);
+
+        $this->assertSame(5, SeatingCardsController::totalCardCount($bookings));
+    }
+
+    public function test_total_card_count_for_multiple_block_bookings()
+    {
+        // Master page + 1 order card per distinct block + 1 card per booking.
+        $bookings = collect([
+            $this->makeBookingStub(1),
+            $this->makeBookingStub(1),
+            $this->makeBookingStub(2),
+            $this->makeBookingStub(2),
+            $this->makeBookingStub(2),
+        ]);
+
+        $this->assertSame(8, SeatingCardsController::totalCardCount($bookings));
+    }
+
+    private function makeBookingStub(int $blockId): object
+    {
+        return (object) [
+            'seat' => (object) [
+                'row' => (object) [
+                    'block' => (object) ['id' => $blockId],
+                ],
+            ],
+        ];
+    }
+
     public function test_seating_cards_generates_pdf_download()
     {
         // Create a user with admin permissions
@@ -103,6 +150,39 @@ class SeatingCardsTest extends TestCase
         $response->assertStatus(200);
         $response->assertHeader('content-type', 'application/pdf');
         $this->assertStringContainsString('seating-cards-conference-2024', $response->headers->get('content-disposition'));
+    }
+
+    public function test_seating_cards_pdf_with_bookings_across_multiple_blocks()
+    {
+        $adminUser = User::factory()->create(['is_admin' => true]);
+
+        $room = Room::factory()->create(['name' => 'Main Hall']);
+        $event = Event::factory()->create(['room_id' => $room->id, 'name' => 'Multi Block Event']);
+
+        $blockA = Block::factory()->create(['room_id' => $room->id, 'name' => 'A', 'type' => 'seating']);
+        $rowA = Row::factory()->create(['block_id' => $blockA->id, 'name' => '1']);
+
+        $blockB = Block::factory()->create(['room_id' => $room->id, 'name' => 'B', 'type' => 'seating']);
+        $rowB = Row::factory()->create(['block_id' => $blockB->id, 'name' => '1']);
+
+        foreach ([$rowA, $rowB] as $row) {
+            for ($i = 1; $i <= 2; $i++) {
+                $seat = Seat::factory()->create(['row_id' => $row->id, 'label' => "S{$i}", 'number' => $i]);
+                Booking::factory()->create([
+                    'event_id' => $event->id,
+                    'seat_id' => $seat->id,
+                    'name' => "Guest {$row->id}-{$i}",
+                    'picked_up_at' => now(),
+                ]);
+            }
+        }
+
+        $response = $this->actingAs($adminUser)
+            ->get(route('admin.events.seating-cards', $event->id));
+
+        // Master page + one order card per block (2) + one card per booking (4) = 7.
+        $response->assertStatus(200);
+        $response->assertHeader('content-type', 'application/pdf');
     }
 
     public function test_seating_cards_requires_admin_access()

--- a/tests/Feature/Admin/SeatingCardsTest.php
+++ b/tests/Feature/Admin/SeatingCardsTest.php
@@ -73,12 +73,48 @@ class SeatingCardsTest extends TestCase
         $this->assertSame(8, SeatingCardsController::totalCardCount($bookings));
     }
 
+    public function test_sort_bookings_for_printing_groups_blocks_and_winds_rows()
+    {
+        // Sorting orders bookings by block position, then winds seats:
+        // ascending on odd rows, descending on even rows.
+        $bookings = collect([
+            $this->makeSeatingBookingStub('B-r2-s1', blockId: 2, posX: 0, posY: 1, rowOrder: 2, seatNumber: 1),
+            $this->makeSeatingBookingStub('A-r1-s2', blockId: 1, posX: 0, posY: 0, rowOrder: 1, seatNumber: 2),
+            $this->makeSeatingBookingStub('B-r2-s2', blockId: 2, posX: 0, posY: 1, rowOrder: 2, seatNumber: 2),
+            $this->makeSeatingBookingStub('A-r1-s1', blockId: 1, posX: 0, posY: 0, rowOrder: 1, seatNumber: 1),
+        ]);
+
+        $sorted = SeatingCardsController::sortBookingsForPrinting($bookings);
+
+        $this->assertSame(
+            ['A-r1-s1', 'A-r1-s2', 'B-r2-s2', 'B-r2-s1'],
+            $sorted->pluck('label')->values()->all()
+        );
+
+        // master + 2 order cards + 4 bookings.
+        $this->assertSame(7, SeatingCardsController::totalCardCount($sorted));
+    }
+
     private function makeBookingStub(int $blockId): object
     {
         return (object) [
             'seat' => (object) [
                 'row' => (object) [
                     'block' => (object) ['id' => $blockId],
+                ],
+            ],
+        ];
+    }
+
+    private function makeSeatingBookingStub(string $label, int $blockId, int $posX, int $posY, int $rowOrder, int $seatNumber): object
+    {
+        return (object) [
+            'label' => $label,
+            'seat' => (object) [
+                'number' => $seatNumber,
+                'row' => (object) [
+                    'order' => $rowOrder,
+                    'block' => (object) ['id' => $blockId, 'position_x' => $posX, 'position_y' => $posY],
                 ],
             ],
         ];
@@ -309,6 +345,7 @@ class SeatingCardsTest extends TestCase
         $room = Room::factory()->create();
         $event = Event::factory()->create([
             'room_id' => $room->id,
+            'name' => 'Winter Gala 2026',
         ]);
         $block = Block::factory()->create(['room_id' => $room->id, 'name' => 'A', 'type' => 'seating']);
         $row = Row::factory()->create(['block_id' => $block->id, 'name' => '1']);
@@ -328,5 +365,6 @@ class SeatingCardsTest extends TestCase
         ])->render();
 
         $this->assertStringContainsString('Not Picked Up', $html);
+        $this->assertStringContainsString('Winter Gala 2026', $html);
     }
 }


### PR DESCRIPTION
move not picked up box to top right
and pagination is in top left
and added a count to bookings

also fixed issue with order card overflowing

Closes #19

<img width="800" height="565" alt="Screenshot 2026-08-19 at 16 42 12" src="https://github.com/user-attachments/assets/655d0fd0-425a-48f6-b990-1e9a2634ae75" />
<img width="804" height="567" alt="Screenshot 2026-08-19 at 16 42 21" src="https://github.com/user-attachments/assets/2dd22def-9a36-4795-a96a-252687528d48" />
<img width="814" height="574" alt="Screenshot 2026-08-19 at 16 42 30" src="https://github.com/user-attachments/assets/c3cba0b9-b7fe-435a-910f-ba10b485422d" />
<img width="802" height="570" alt="Screenshot 2026-08-19 at 16 42 38" src="https://github.com/user-attachments/assets/2a16129a-deb9-4f0b-9645-77d5e261a407" />

